### PR TITLE
Ignore The Clock by TwitchBlinds mod

### DIFF
--- a/Items/Blinds.lua
+++ b/Items/Blinds.lua
@@ -365,6 +365,11 @@ local clock = {
             "3 seconds spent this ante"
         }
     },
+    config = {
+        tw_bl = {
+            ignore = true
+        }
+    },
     atlas = "blinds",
     boss_colour = HEX('853455'),
     defeat = function(self, silent)


### PR DESCRIPTION
Referencing [this message](https://discord.com/channels/1116389027176787968/1267185254633050153/1267190778669699092).
Added config to The Clock blind to be ignored by Twitch Blinds mod, so it can't appear with zero score.

Obsidian Orb also has this mechanic, but due to it's scaling speed I decide to leave them as it is.