### PR TITLE
More aggressive dependencies

### DIFF
--- a/Cryptid.lua
+++ b/Cryptid.lua
@@ -5,7 +5,7 @@
 --- MOD_AUTHOR: [MathIsFun_, Balatro Discord]
 --- MOD_DESCRIPTION: Adds unbalanced ideas to Balatro.
 --- BADGE_COLOUR: 708b91
---- DEPENDENCIES: [Talisman]
+--- DEPENDENCIES: [Talisman>=2.0.0-beta3, Steamodded>=1.0.0-ALPHA-0805d]
 --- VERSION: 0.4.3f
 
 ----------------------------------------------


### PR DESCRIPTION
Add Steamodded version dependency (moved from `LOADER_VERSION_GEQ` in latest) and ensure Talisman is up to date, so version mismatches show a warning in the mods menu instead of crashing.