### PR TITLE
fix: steamodded version requirement change

### DIFF
--- a/Cryptid.lua
+++ b/Cryptid.lua
@@ -5,7 +5,7 @@
 --- MOD_AUTHOR: [MathIsFun_, Balatro Discord]
 --- MOD_DESCRIPTION: Adds unbalanced ideas to Balatro.
 --- BADGE_COLOUR: 708b91
---- DEPENDENCIES: [Talisman>=2.0.0-beta3, Steamodded>=1.0.0-ALPHA-0805d]
+--- DEPENDENCIES: [Talisman>=2.0.0-beta3, Steamodded>=1.0.0~ALPHA-0812d]
 --- VERSION: 0.4.3i
 
 ----------------------------------------------


### PR DESCRIPTION
Fixes a breaking change made in steamodded. Also I tested and having the tilde with the older version is not accepted by any versions before the tilde change so new minumum steamodded version