### PR TITLE
Add JokerDisplay joker retrigger functionality + some fixes

### DIFF
--- a/Items/MiscJokers.lua
+++ b/Items/MiscJokers.lua
@@ -4296,11 +4296,17 @@ if JokerDisplay then
         },
         extra_config = { colour = G.C.GREEN, scale = 0.3 },
         calc_function = function(card)
-            card.ability.name = "Blueprint" --funny workaround
             local copied_joker, copied_debuff = JokerDisplay.calculate_blueprint_copy(card)
-            card.ability.name = "cry-oldblueprint"
             card.joker_display_values.blueprint_compat = localize('k_incompatible')
             JokerDisplay.copy_display(card, copied_joker, copied_debuff)
+        end,
+        get_blueprint_joker = function (card)
+            for i = 1, #G.jokers.cards do
+				if G.jokers.cards[i] == card then
+					return G.jokers.cards[i + 1]
+				end
+			end
+            return nil
         end
     }
 end

--- a/Items/MiscJokers.lua
+++ b/Items/MiscJokers.lua
@@ -61,7 +61,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "x_mult" }
+                    { ref_table = "card.ability.extra", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -140,7 +140,17 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "^" },
-                    { ref_table = "card.joker_display_values", ref_value = "e_mult" }
+                    { 
+                        ref_table = "card.joker_display_values",
+                        ref_value = "e_mult",
+                        retrigger_type = function (number, triggers)
+                            local num = number
+                            for i=1, triggers-1 do
+                                num = num ^ number
+                            end
+                            return num
+                        end
+                    }
                 },
                 border_colour = G.C.DARK_EDITION
             }
@@ -312,7 +322,7 @@ if JokerDisplay then
     wee_fib.joker_display_definition = {
         text = {
             { text = "+" },
-            { ref_table = "card.ability.extra", ref_value = "mult" }
+            { ref_table = "card.ability.extra", ref_value = "mult", retrigger_type = "mult" }
         },
         text_config = { colour = G.C.MULT },
         reminder_text = {
@@ -376,7 +386,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "x_mult" }
+                    { ref_table = "card.ability.extra", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -422,7 +432,7 @@ local lucky_joker = {
 if JokerDisplay then
     lucky_joker.joker_display_definition = {
         text = {
-            { ref_table = "card.joker_display_values", ref_value = "count" },
+            { ref_table = "card.joker_display_values", ref_value = "count", retrigger_type = "mult" },
             { text = "x",                              scale = 0.35 },
             { text = "$",                              colour = G.C.GOLD },
             { ref_table = "card.ability.extra",        ref_value = "dollars", colour = G.C.GOLD },
@@ -489,7 +499,7 @@ if JokerDisplay then
     cursor.joker_display_definition = {
         text = {
             { text = "+" },
-            { ref_table = "card.ability.extra", ref_value = "chips" }
+            { ref_table = "card.ability.extra", ref_value = "chips", retrigger_type = "mult" }
         },
         text_config = { colour = G.C.CHIPS },
     }
@@ -570,11 +580,13 @@ if JokerDisplay then
     pickle.joker_display_definition = {
         reminder_text = {
             { text = '(', },
+            { text = '+', colour = G.C.ORANGE },
+            { ref_table = "card.ability.extra", ref_value = "tags", colour = G.C.ORANGE, retrigger_type = "mult" },
             { ref_table = "card.joker_display_values", ref_value = "localized_text", colour = G.C.ORANGE },
             { text = ')', },
         },
         calc_function = function(card)
-            card.joker_display_values.localized_text = "+" .. card.ability.extra.tags .. " " .. localize("b_tags")
+            card.joker_display_values.localized_text = " " .. localize("b_tags")
         end
     }
 end
@@ -611,7 +623,7 @@ if JokerDisplay then
     cube.joker_display_definition = {
         text = {
             { text = "+" },
-            { ref_table = "card.ability.extra", ref_value = "chips" }
+            { ref_table = "card.ability.extra", ref_value = "chips", retrigger_type = "mult" }
         },
         text_config = { colour = G.C.CHIPS },
     }
@@ -659,7 +671,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.joker_display_values", ref_value = "x_mult" }
+                    { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -776,7 +788,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "Xmult" }
+                    { ref_table = "card.ability.extra", ref_value = "Xmult", retrigger_type = "exp" }
                 }
             }
         },
@@ -871,7 +883,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "x_chips" }
+                    { ref_table = "card.ability.extra", ref_value = "x_chips", retrigger_type = "exp" }
                 },
                 border_colour = G.C.CHIPS
             }
@@ -919,7 +931,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "x_mult" }
+                    { ref_table = "card.ability.extra", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -970,7 +982,7 @@ if JokerDisplay then
     nice.joker_display_definition = {
         text = {
             { text = "+", },
-            { ref_table = "card.joker_display_values", ref_value = "chips" },
+            { ref_table = "card.joker_display_values", ref_value = "chips", retrigger_type = "mult" },
         },
         text_config = { colour = G.C.CHIPS },
         reminder_text = {
@@ -1077,7 +1089,10 @@ if JokerDisplay then
                 G.jokers.cards[1].config.center.key
             card.joker_display_values.localized_text = leftmost_joker_key and
                 localize { type = 'name_text', key = leftmost_joker_key, set = 'Joker' } or "-"
-        end
+        end,
+        retrigger_joker_function = function (card, retrigger_joker)
+			return card ~= retrigger_joker and G.jokers.cards[1] == card and retrigger_joker.ability.extra.retriggers or 0
+		end
     }
 end
 local jimball = {
@@ -1133,7 +1148,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.joker_display_values", ref_value = "x_mult" }
+                    { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -1276,7 +1291,7 @@ if JokerDisplay then
     fspinner.joker_display_definition = {
         text = {
             { text = "+" },
-            { ref_table = "card.joker_display_values", ref_value = "chips" }
+            { ref_table = "card.joker_display_values", ref_value = "chips", retrigger_type = "mult" }
         },
         text_config = { colour = G.C.CHIPS },
         calc_function = function(card)
@@ -1336,7 +1351,7 @@ local waluigi = {
 if JokerDisplay then
     waluigi.joker_display_definition = {
         mod_function = function(card, mod_joker)
-            return { x_mult = mod_joker.ability.extra.Xmult }
+            return { x_mult = mod_joker.ability.extra.Xmult ^ JokerDisplay.calculate_joker_triggers(mod_joker) }
         end
     }
 end
@@ -1385,7 +1400,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "x_mult" }
+                    { ref_table = "card.ability.extra", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -1459,7 +1474,7 @@ if JokerDisplay then
     gardenfork.joker_display_definition = {
         text = {
             { text = "+$" },
-            { ref_table = "card.joker_display_values", ref_value = "dollars" },
+            { ref_table = "card.joker_display_values", ref_value = "dollars", retrigger_type = "mult" },
         },
         text_config = { colour = G.C.GOLD },
         reminder_text = {
@@ -1525,7 +1540,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.joker_display_values", ref_value = "x_mult" }
+                    { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -1544,7 +1559,7 @@ if JokerDisplay then
                     end
                 end
             end
-            card.joker_display_values.x_mult = tonumber(string.format("%.2f", (card.ability.extra.xmult ^ count)))
+            card.joker_display_values.x_mult = card.ability.extra.xmult ^ count
         end,
     }
 end
@@ -1587,7 +1602,8 @@ if JokerDisplay then
     nosound.joker_display_definition = {
         retrigger_function = function(playing_card, scoring_hand, held_in_hand, joker_card)
             if held_in_hand then return 0 end
-            return playing_card:get_id() and playing_card:get_id() == 7 and joker_card.ability.extra.retriggers or 0
+            return playing_card:get_id() and playing_card:get_id() == 7 and
+                joker_card.ability.extra.retriggers * JokerDisplay.calculate_joker_triggers(joker_card) or 0
         end
     }
 end
@@ -1641,7 +1657,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "x_chips" }
+                    { ref_table = "card.ability.extra", ref_value = "x_chips", retrigger_type = "exp" }
                 },
                 border_colour = G.C.CHIPS
             }
@@ -1721,7 +1737,8 @@ if JokerDisplay then
     weegaming.joker_display_definition = {
         retrigger_function = function(playing_card, scoring_hand, held_in_hand, joker_card)
             if held_in_hand then return 0 end
-            return playing_card:get_id() and playing_card:get_id() == 2 and joker_card.ability.extra.retriggers or 0
+            return playing_card:get_id() and playing_card:get_id() == 2 and 
+                joker_card.ability.extra.retriggers * JokerDisplay.calculate_joker_triggers(joker_card) or 0
         end
     }
 end
@@ -1841,7 +1858,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.joker_display_values", ref_value = "x_mult" }
+                    { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -2030,7 +2047,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "x_mult" }
+                    { ref_table = "card.ability.extra", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -2091,7 +2108,7 @@ if JokerDisplay then
     monkey_dagger.joker_display_definition = {
         text = {
             { text = "+" },
-            { ref_table = "card.ability.extra", ref_value = "chips" }
+            { ref_table = "card.ability.extra", ref_value = "chips", retrigger_type = "mult" }
         },
         text_config = { colour = G.C.CHIPS },
     }
@@ -2153,7 +2170,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "x_chips" }
+                    { ref_table = "card.ability.extra", ref_value = "x_chips", retrigger_type = "exp" }
                 },
                 border_colour = G.C.CHIPS
             }
@@ -2205,7 +2222,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "x_mult" }
+                    { ref_table = "card.ability.extra", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -2270,7 +2287,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "Xmult" }
+                    { ref_table = "card.ability.extra", ref_value = "Xmult", retrigger_type = "exp" }
                 },
                 border_colour = G.C.DARK_EDITION
             }
@@ -2392,7 +2409,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "x_chips" }
+                    { ref_table = "card.ability.extra", ref_value = "x_chips", retrigger_type = "exp" }
                 },
                 border_colour = G.C.CHIPS
             }
@@ -2528,7 +2545,7 @@ if JokerDisplay then
     meteor.joker_display_definition = {
         text = {
             { text = "+" },
-            { ref_table = "card.joker_display_values", ref_value = "chips" }
+            { ref_table = "card.joker_display_values", ref_value = "chips", retrigger_type = "mult" }
         },
         text_config = { colour = G.C.CHIPS },
         reminder_text = {
@@ -2618,7 +2635,7 @@ if JokerDisplay then
     exoplanet.joker_display_definition = {
         text = {
             { text = "+" },
-            { ref_table = "card.joker_display_values", ref_value = "mult" }
+            { ref_table = "card.joker_display_values", ref_value = "mult", retrigger_type = "mult" }
         },
         text_config = { colour = G.C.MULT },
         reminder_text = {
@@ -2710,7 +2727,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.joker_display_values", ref_value = "x_mult" }
+                    { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -2730,7 +2747,7 @@ if JokerDisplay then
                     end
                 end
             end
-            card.joker_display_values.x_mult = tonumber(string.format("%.2f", (card.ability.extra.xmult ^ count)))
+            card.joker_display_values.x_mult = card.ability.extra.xmult ^ count
             card.joker_display_values.localized_text = localize { type = 'name_text', set = 'Edition', key = "e_polychrome" }
         end
     }
@@ -3832,7 +3849,7 @@ local hand_xmult_jd = {
         {
             border_nodes = {
                 { text = "X" },
-                { ref_table = "card.joker_display_values", ref_value = "x_mult" }
+                { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
             }
         }
     },
@@ -3843,8 +3860,8 @@ local hand_xmult_jd = {
     },
     calc_function = function(card)
         local x_mult = 1
-        local _, poker_hands, _ = JokerDisplay.evaluate_hand()
-        if poker_hands[card.ability.type] and next(poker_hands[card.ability.type]) then
+        local text, poker_hands, _ = JokerDisplay.evaluate_hand()
+        if text ~= "Unknown" and poker_hands[card.ability.type] and next(poker_hands[card.ability.type]) then
             x_mult = card.ability.x_mult
         end
         card.joker_display_values.x_mult = x_mult
@@ -4180,7 +4197,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.ability.extra", ref_value = "x_mult" }
+                    { ref_table = "card.ability.extra", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -4355,7 +4372,17 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "^" },
-                    { ref_table = "card.joker_display_values", ref_value = "e_mult" }
+                    { 
+                        ref_table = "card.joker_display_values",
+                        ref_value = "e_mult",
+                        retrigger_type = function (number, triggers)
+                            local num = number
+                            for i=1, triggers-1 do
+                                num = num ^ number
+                            end
+                            return num
+                        end
+                    }
                 },
                 border_colour = G.C.DARK_EDITION
             }

--- a/Items/xEpicJokers.lua
+++ b/Items/xEpicJokers.lua
@@ -44,16 +44,16 @@ if JokerDisplay then
 	supercell.joker_display_definition = {
 		text = {
 			{ text = "+",                       colour = G.C.CHIPS },
-			{ ref_table = "card.ability.extra", ref_value = "stat1", colour = G.C.CHIPS },
+			{ ref_table = "card.ability.extra", ref_value = "stat1", colour = G.C.CHIPS, retrigger_type = "mult" },
 			{ text = " +",                      colour = G.C.MULT },
-			{ ref_table = "card.ability.extra", ref_value = "stat1", colour = G.C.MULT },
+			{ ref_table = "card.ability.extra", ref_value = "stat1", colour = G.C.MULT, retrigger_type = "mult" },
 		},
 		extra = {
 			{
 				{
 					border_nodes = {
 						{ text = "X" },
-						{ ref_table = "card.ability.extra", ref_value = "stat2" }
+						{ ref_table = "card.ability.extra", ref_value = "stat2", retrigger_type = "exp" }
 					},
 					border_colour = G.C.CHIPS
 				},
@@ -61,7 +61,7 @@ if JokerDisplay then
 				{
 					border_nodes = {
 						{ text = "X" },
-						{ ref_table = "card.ability.extra", ref_value = "stat2" }
+						{ ref_table = "card.ability.extra", ref_value = "stat2", retrigger_type = "exp" }
 					}
 				}
 			},
@@ -114,7 +114,7 @@ if JokerDisplay then
 			{
 				border_nodes = {
 					{ text = "X" },
-					{ ref_table = "card.ability.extra", ref_value = "Xmult" }
+					{ ref_table = "card.ability.extra", ref_value = "Xmult", retrigger_type = "exp" }
 				}
 			}
 		},
@@ -239,6 +239,9 @@ if JokerDisplay then
 				end
 			end
 			card.joker_display_values.num_retriggers = num_retriggers
+		end,
+		retrigger_joker_function = function (card, retrigger_joker)
+			return card.T.x + card.T.w / 2 < retrigger_joker.T.x + retrigger_joker.T.w / 2 and retrigger_joker.joker_display_values.num_retriggers or 0
 		end
 	}
 end
@@ -381,7 +384,7 @@ if JokerDisplay then
 			{
 				border_nodes = {
 					{ text = "X" },
-					{ ref_table = "card.ability.extra", ref_value = "x_mult" }
+					{ ref_table = "card.ability.extra", ref_value = "x_mult", retrigger_type = "exp" }
 				}
 			}
 		},
@@ -964,7 +967,7 @@ if JokerDisplay then
 			{
 				border_nodes = {
 					{ text = "X" },
-					{ ref_table = "card.joker_display_values", ref_value = "x_mult" }
+					{ ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
 				}
 			}
 		},
@@ -981,7 +984,7 @@ if JokerDisplay then
 						JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
 				end
 			end
-			card.joker_display_values.x_mult = tonumber(string.format("%.2f", (card.ability.extra.x_mult ^ count)))
+			card.joker_display_values.x_mult = card.ability.extra.x_mult ^ count
 	
 			card.joker_display_values.start_round = card.joker_display_values.start_round or
 				card.ability.extra.rounds_remaining
@@ -1278,7 +1281,7 @@ if JokerDisplay then
 					end
 				end
 			end
-            card.joker_display_values.count = count
+            card.joker_display_values.count = math.min(count, 2-card.ability.extra.check)
             card.joker_display_values.odds = G.GAME and G.GAME.probabilities.normal or 1
 		end
 	}
@@ -1331,7 +1334,7 @@ if JokerDisplay then
 	multjoker.joker_display_definition = {
 		text = {
             { text = "+" },
-            { ref_table = "card.joker_display_values", ref_value = "count" },
+            { ref_table = "card.joker_display_values", ref_value = "count", retrigger_type = "mult" },
         },
         text_config = { colour = G.C.SECONDARY_SET.Spectral },
         extra = {

--- a/Items/zExotic.lua
+++ b/Items/zExotic.lua
@@ -94,7 +94,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.joker_display_values", ref_value = "x_mult" }
+                    { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
                 }
             }
         },
@@ -108,11 +108,11 @@ if JokerDisplay then
                         JokerDisplay.calculate_card_triggers(scoring_card, scoring_hand)
                 end
             end
-            card.joker_display_values.x_mult = tonumber(string.format("%.2f", (card.ability.extra.x_mult ^ count)))
+            card.joker_display_values.x_mult = card.ability.extra.x_mult ^ count
         end,
         retrigger_function = function(playing_card, scoring_hand, held_in_hand, joker_card)
             if held_in_hand then return 0 end
-            return joker_card.ability.extra.repetitions or 0
+            return (joker_card.ability.extra.repetitions * JokerDisplay.calculate_joker_triggers(joker_card)) or 0
         end
     }
 end
@@ -183,7 +183,17 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "^" },
-                    { ref_table = "card.ability.extra", ref_value = "Emult" }
+                    { 
+                        ref_table = "card.ability.extra",
+                        ref_value = "Emult",
+                        retrigger_type = function (number, triggers)
+                            local num = number
+                            for i=1, triggers-1 do
+                                num = num ^ number
+                            end
+                            return num
+                        end
+                    }
                 },
                 border_colour = G.C.DARK_EDITION
             }
@@ -409,7 +419,7 @@ if JokerDisplay then
     crustulum.joker_display_definition = {
         text = {
             { text = "+" },
-            { ref_table = "card.ability.extra", ref_value = "chips" }
+            { ref_table = "card.ability.extra", ref_value = "chips", retrigger_type = "mult" }
         },
         text_config = { colour = G.C.CHIPS },
     }
@@ -474,7 +484,17 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "^" },
-                    { ref_table = "card.ability.extra", ref_value = "Emult" }
+                    { 
+                        ref_table = "card.ability.extra",
+                        ref_value = "Emult",
+                        retrigger_type = function (number, triggers)
+                            local num = number
+                            for i=1, triggers-1 do
+                                num = num ^ number
+                            end
+                            return num
+                        end
+                    }
                 },
                 border_colour = G.C.DARK_EDITION
             }
@@ -834,7 +854,17 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "^" },
-                    { ref_table = "card.ability.extra", ref_value = "Emult" }
+                    { 
+                        ref_table = "card.ability.extra",
+                        ref_value = "Emult",
+                        retrigger_type = function (number, triggers)
+                            local num = number
+                            for i=1, triggers-1 do
+                                num = num ^ number
+                            end
+                            return num
+                        end
+                    }
                 },
                 border_colour = G.C.DARK_EDITION
             }

--- a/Items/zM.lua
+++ b/Items/zM.lua
@@ -271,7 +271,7 @@ if JokerDisplay then
     foodm.joker_display_definition = {
         text = {
             { text = "+" },
-            { ref_table = "card.ability.extra", ref_value = "mult" }
+            { ref_table = "card.ability.extra", ref_value = "mult", retrigger_type = "mult" }
         },
         text_config = { colour = G.C.MULT },
         reminder_text = {
@@ -352,12 +352,12 @@ if JokerDisplay then
     mstack.joker_display_definition = {
         reminder_text = {
             { text = "(" },
-            { ref_table = "card.ability.extra", ref_value = "retriggers", colour = G.C.ORANGE },
+            { ref_table = "card.ability.extra", ref_value = "retriggers", colour = G.C.ORANGE, retrigger_type = "mult" },
             { text = ")" },
         },
         retrigger_function = function(playing_card, scoring_hand, held_in_hand, joker_card)
             if held_in_hand then return 0 end
-            return joker_card.ability.extra.retriggers or 0
+            return (joker_card.ability.extra.retriggers * JokerDisplay.calculate_joker_triggers(joker_card)) or 0
         end
     }
 end
@@ -600,7 +600,7 @@ if JokerDisplay then
             if card.ability.name == "Jolly Joker" then
                 chips_mod = chips_mod * mod_joker.ability.extra.xchips
             end
-            return { chips = chips_mod or nil }
+            return { chips = chips_mod * JokerDisplay.calculate_joker_triggers(mod_joker) or nil }
         end
     }
 end
@@ -732,6 +732,17 @@ local loopy = { --this may or may not need further balancing
         end
     end
 }
+if JokerDisplay then
+	loopy.joker_display_definition = {
+		text = {
+			{ text = "x" },
+			{ ref_table = "card.ability.extra", ref_value = "retrigger" },
+		},
+		retrigger_joker_function = function (card, retrigger_joker)
+			return retrigger_joker.ability.extra.retrigger or 0
+		end
+	}
+end
 local scrabble = {
 	object_type = "Joker",
 	name = "cry-scrabble",
@@ -1087,7 +1098,7 @@ if JokerDisplay then
             {
                 border_nodes = {
                     { text = "X" },
-                    { ref_table = "card.joker_display_values", ref_value = "x_chips" }
+                    { ref_table = "card.joker_display_values", ref_value = "x_chips", retrigger_type = "exp" }
                 },
                 border_colour = G.C.CHIPS
             }
@@ -1161,9 +1172,8 @@ biggestm.joker_display_definition = {
         {
             border_nodes = {
                 { text = "X" },
-                { ref_table = "card.joker_display_values", ref_value = "x_mult" }
+                { ref_table = "card.joker_display_values", ref_value = "x_mult", retrigger_type = "exp" }
             },
-            border_colour = G.C.MULT
         }
     },
     reminder_text = {

--- a/Items/zM.lua
+++ b/Items/zM.lua
@@ -1266,13 +1266,19 @@ local hugem = {
 	end,
 }
 if JokerDisplay then
-    --[[hugem.joker_display_definition = {
+    hugem.joker_display_definition = {
         --todo: show if active
         mod_function = function(card, mod_joker)
-            return { pow_mult = (card.ability.name == "Jolly Joker" and mod_joker.ability.extra.mult) }
+            if card.ability.name ~= "Jolly Joker" then return {} end
+            local e_mult = mod_joker.ability.extra.mult
+            local triggers = JokerDisplay.calculate_joker_triggers(mod_joker)
+            if triggers == 0 then return {} end
+            for i=1, triggers-1 do
+                e_mult = e_mult ^ mod_joker.ability.extra.mult
+            end
+            return { e_mult = e_mult }
         end
-    }--]]
-    --pow_mult doesn't work yet here :(
+    }
 end
 local macabre = {
     object_type = "Joker",


### PR DESCRIPTION
I haven't tested every single Joker to now if it's doing the right calculation but it at least shouldn't crash in any instance (hopefully)

Some extra fixes:

* It's no longer necessary to manually format Xmult text
* Hand Xmult Jokers check if text is "Unknown" so they don't cheat by looking through facedown cards
* Changed some stuff in the API to make Old Blueprint's display code less clunky
* Bonus Joker count now caps at 2 (as per the ability)
* Added e_mult modifier to the API for Tredecim