### PR TITLE
Fix type mismatch errors in shader code

### DIFF
--- a/assets/shaders/astral.fs
+++ b/assets/shaders/astral.fs
@@ -107,7 +107,7 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 
 	vec4 hsl = HSL(vec4(tex.r*saturation_fac, tex.g*saturation_fac, tex.b, tex.a));
 
-	float t = astral.y*2.221 + mod(time,1);
+	float t = astral.y*2.221 + mod(time,1.);
 	vec2 floored_uv = (floor((uv*texture_details.ba)))/texture_details.ba;
     vec2 uv_scaled_centered = (floored_uv - 0.5) * 50.;
 	
@@ -122,7 +122,7 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     float res = (.5 + .5* cos( (astral.x) * 2.612 + ( field + -.5 ) *3.14));
 	hsl.x = .8;
 	hsl.y = hsl.y * 0.8;
-	hsl.z = hsl.z * 0.2 + 0.6 * sin(hsl.z/2.5 - res/4 + sin(astral.y)/8 + 0.5)/1.4;
+	hsl.z = hsl.z * 0.2 + 0.6 * sin(hsl.z/2.5 - res/4. + sin(astral.y)/8. + 0.5)/1.4;
 
     tex.rgb = RGB(hsl).rgb;
 

--- a/assets/shaders/blur.fs
+++ b/assets/shaders/blur.fs
@@ -59,7 +59,7 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 
     // Adjust lightness for a glossy effect
 
-    float t = blur.y*2.221 + mod(time,1);
+    float t = blur.y*2.221 + mod(time,1.);
 	vec2 floored_uv = (floor((uv*texture_details.ba)))/texture_details.ba;
     vec2 uv_scaled_centered = (floored_uv - 0.5) * 50.;
 	
@@ -73,7 +73,7 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 
     float res = (.5 + .5* cos( (blur.x) * 2.612 + ( field + -.5 ) *3.14));
     // Mostly use original lightness, with slight change from moving the card & with time
-	hsl.z = 0.7*hsl.z + sin(hsl.z/2.5 - res/4 + sin(blur.y)/8 + 0.5)/3.;
+	hsl.z = 0.7*hsl.z + sin(hsl.z/2.5 - res/4. + sin(blur.y)/8. + 0.5)/3.;
 
     final_pixel = RGB(hsl);
 

--- a/assets/shaders/glitched.fs
+++ b/assets/shaders/glitched.fs
@@ -112,8 +112,8 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     float iTime = tan(2. * time);
 
     texCoordsR.x += (0.004 * rand(vec2(iTime, uv.y))) - 0.002 + (POLY_THROWAWAY * 0.0000001);
-    texCoordsG.x += (0.007 * rand(vec2(iTime*2, uv.y*0.9))) - 0.0035 + (POLY_THROWAWAY * 0.0000001);
-    texCoordsB.x += (0.010 * rand(vec2(iTime*3, uv.y*0.8))) - 0.005 + (POLY_THROWAWAY_2 * 0.0000001);
+    texCoordsG.x += (0.007 * rand(vec2(iTime*2., uv.y*0.9))) - 0.0035 + (POLY_THROWAWAY * 0.0000001);
+    texCoordsB.x += (0.010 * rand(vec2(iTime*3., uv.y*0.8))) - 0.005 + (POLY_THROWAWAY_2 * 0.0000001);
     
     vec4 texR = Texel(texture, texCoordsR);
     vec4 texG = Texel(texture, texCoordsG);

--- a/assets/shaders/mosaic.fs
+++ b/assets/shaders/mosaic.fs
@@ -119,7 +119,7 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 	number delta = 0.2+0.3*(high- low) + 0.1*high;
 
 	number gridsize = 0.6;
-    number fac = max(max(0., 7.*abs(cos(uv.x*gridsize*20.))-6.), max(0., 7.*cos(uv.y*gridsize*45)-6.));
+    number fac = max(max(0., 7.*abs(cos(uv.x*gridsize*20.))-6.), max(0., 7.*cos(uv.y*gridsize*45.)-6.));
 	
 	hsl.x = hsl.x + res + fac;
 	hsl.y = hsl.y*1.3;	

--- a/assets/shaders/noisy.fs
+++ b/assets/shaders/noisy.fs
@@ -30,7 +30,7 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 
     float random = rand(uv);
 
-    if (pixel.a > 0) pixel.a += 0.1*sin(noisy.x) - 0.51;
+    if (pixel.a > 0.) pixel.a += 0.1*sin(noisy.x) - 0.51;
 	
 	return dissolve_mask(vec4(pixel.rgb * random, pixel.a), texture_coords, uv);
 }

--- a/assets/shaders/oversat.fs
+++ b/assets/shaders/oversat.fs
@@ -202,8 +202,8 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
         cos(length(field_part3) / 27.193) * sin(field_part3.x / 21.92) ))/2.;
 
     float res = (.5 + .5* cos( (oversat.x) * 2.612 + ( field + -.5 ) *3.14));
-    tex = RGB(hsl);
-    tex.rgb = increaseContrast(tex.rgb,4);
+    vec4 textp = RGB(hsl);
+    tex.rgb = increaseContrast(textp.rgb,4.0);
 	return dissolve_mask(tex*colour, texture_coords, uv);
 }
 


### PR DESCRIPTION
Refactored GLSL code to avoid implicit type conversions between float and int. Explicit type casting has been added to ensure compatibility with strict compilers.