### PR TITLE
Remove buggy patch from Misprint.toml (and fix a crash)

### DIFF
--- a/Cryptid.lua
+++ b/Cryptid.lua
@@ -1954,7 +1954,7 @@ local gfcsc = G.FUNCS.can_select_card
 G.FUNCS.can_select_card = function(e)
   if (e.config.ref_table.ability.name == "cry-Negative Joker" and card.config.ref_table.ability.extra >= 1) or
 	(e.config.ref_table.ability.name == "cry-soccer" and card.config.ref_table.ability.extra.holygrail >= 1) or 
-	(e.config.ref_table.config.ref_table.ability.name == "cry-Tenebris" and card.config.ref_table.ability.extra.slots >= 1) then 
+	(e.config.ref_table.ability.name == "cry-Tenebris" and card.config.ref_table.ability.extra.slots >= 1) then 
     e.config.colour = G.C.GREEN
     e.config.button = 'use_card'
   else

--- a/Cryptid.lua
+++ b/Cryptid.lua
@@ -1952,9 +1952,9 @@ end
 
 local gfcsc = G.FUNCS.can_select_card
 G.FUNCS.can_select_card = function(e)
-  if (card.config.ref_table.ability.name == "cry-Negative Joker" and card.config.ref_table.ability.extra >= 1) or
-	(card.config.ref_table.ability.name == "cry-soccer" and card.config.ref_table.ability.extra.holygrail >= 1) or 
-	(card.config.ref_table.config.ref_table.ability.name == "cry-Tenebris" and card.config.ref_table.ability.extra.slots >= 1) then 
+  if (e.config.ref_table.ability.name == "cry-Negative Joker" and card.config.ref_table.ability.extra >= 1) or
+	(e.config.ref_table.ability.name == "cry-soccer" and card.config.ref_table.ability.extra.holygrail >= 1) or 
+	(e.config.ref_table.config.ref_table.ability.name == "cry-Tenebris" and card.config.ref_table.ability.extra.slots >= 1) then 
     e.config.colour = G.C.GREEN
     e.config.button = 'use_card'
   else

--- a/lovely/Misprint.toml
+++ b/lovely/Misprint.toml
@@ -175,20 +175,6 @@ position = "at"
 payload = "ease_ante(math.floor(-center_table.extra))"
 match_indent = true
 
-# Consumables lying to you
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = "function Card:use_consumeable(area, copier)"
-position = "after"
-payload = '''
-if self.ability.set ~= "Gear" and not (self.ability.extra and type(self.ability.extra) == "table" and self.ability.extra.local_d6_sides) then --Ro-Balatro and D6 Jokers compat, I need a better system for this later
-for k, v in pairs(G.P_CENTERS[self.config.center_key].config) do
-        self.ability[k] = v --surely nothing will go wrong
-    end
-end'''
-match_indent = true
-
 # Get Cryptid to display and work with card selections
 [[patches]]
 [patches.pattern]


### PR DESCRIPTION
the patch overwrites the fields of card.ability, which causes issues with colour cards
removing it (probably) doesn't cause any issues with existing consumeables