### PR TITLE
Fix Ace Aequilibrium crash in aeqviable

### DIFF
--- a/Cryptid.lua
+++ b/Cryptid.lua
@@ -1629,8 +1629,8 @@ function create_card(_type, area, legendary, _rarity, skip_materialize, soulable
 	if (_type == "Joker") and not forced_key and G.GAME and G.GAME.modifiers and G.GAME.modifiers.all_rnj then
 		forced_key = "j_cry_rnjoker"
 	end
-	local function aeqviable(card)
-		return not Card.no(card, "doe") and not Card.no(card, "aeq") and not (card.rarity == 6 or card.rarity == "cry_exotic")
+	local function aeqviable(center)
+		return not center_no(center, "doe") and not center_no(center, "aeq") and not (center.rarity == 6 or center.rarity == "cry_exotic")
 	end
 	if _type == "Joker" and not _rarity then
 		local aeqactive = nil


### PR DESCRIPTION
I'm not 100% familiar with the codebase, so please double check this. 

After looking at the history and the objects involved, I'm pretty sure center_no was supposed to be used rather than Card.no(), since the tables being fed into this local function aren't cards.