### PR TITLE
Fix crash when spawning steel joker during scoring (Scrabble tile, Ace Aequilibrium)

### DIFF
--- a/Cryptid.lua
+++ b/Cryptid.lua
@@ -1959,6 +1959,10 @@ function create_card(_type, area, legendary, _rarity, skip_materialize, soulable
 	if card.ability.name == "cry-stardust" then
 		card:set_edition("e_polychrome", true, nil, true)
 	end
+	-- Certain jokers such as Steel Joker and Driver's License depend on values set 
+	-- during the update function. Cryptid can create jokers mid-scoring, meaning
+	-- those values will be unset during scoring unless update() is manually called.
+	card:update(0.016) -- dt is unused in the base game, but we're providing a realistic value anyway
 	return card
 end
 


### PR DESCRIPTION
Steel Joker and others use the value set during Card.update(dt) in order to set values used during scoring calculation. If these jokers are created during scoring, update() won't be called in time, and the game will crash due to unset values.

Manually calling update() on the card after spawning it fixes the crash.