### PR TITLE
Update Exotic.lua

### DIFF
--- a/Items/Exotic.lua
+++ b/Items/Exotic.lua
@@ -726,6 +726,11 @@ local aequilibrium = {
 			end
 		end
 	end,
+	remove_from_deck = function(self, card, from_debuff)
+		if not from_debuff then
+			card.ability.extra.card:start_dissolve()
+		end
+	end,
 }
 local cc = copy_card
 function copy_card(card, a, b, c, d)


### PR DESCRIPTION
Removes the Ace card from Ace Aequilibrium when it is removed.