### PR TITLE
Prevent Crash on Sync due to invalid hand

### DIFF
--- a/Items/EpicJokers.lua
+++ b/Items/EpicJokers.lua
@@ -117,7 +117,7 @@ local sync_catalyst = {
 	calculate = function(self, card, context)
 		if context.cardarea == G.jokers and not context.before and not context.after then
 			local tot = hand_chips + mult
-			if not debuffed_hand then -- Adding Guard clause to protect against unallowed hands
+			if not context.debuffed_hand then -- Adding Guard clause to protect against unallowed hands
 				if not tot.array or #tot.array < 2 or tot.array[2] < 2 then --below eXeY notation
 					hand_chips = mod_chips(math.floor(tot / 2))
 					mult = mod_mult(math.floor(tot / 2))

--- a/Items/EpicJokers.lua
+++ b/Items/EpicJokers.lua
@@ -117,23 +117,25 @@ local sync_catalyst = {
 	calculate = function(self, card, context)
 		if context.cardarea == G.jokers and not context.before and not context.after then
 			local tot = hand_chips + mult
-			if not tot.array or #tot.array < 2 or tot.array[2] < 2 then --below eXeY notation
-				hand_chips = mod_chips(math.floor(tot / 2))
-				mult = mod_mult(math.floor(tot / 2))
-			else
-				if hand_chips > mult then
-					tot = hand_chips
+			if not (type(tot) == "number") then -- Adding Guard clause to protect against unalowed hands
+				if not tot.array or #tot.array < 2 or tot.array[2] < 2 then --below eXeY notation
+					hand_chips = mod_chips(math.floor(tot / 2))
+					mult = mod_mult(math.floor(tot / 2))
 				else
-					tot = mult
+					if hand_chips > mult then
+						tot = hand_chips
+					else
+						tot = mult
+					end
+					hand_chips = mod_chips(tot)
+					mult = mod_chips(tot)
 				end
-				hand_chips = mod_chips(tot)
-				mult = mod_chips(tot)
+				update_hand_text({ delay = 0 }, { mult = mult, chips = hand_chips })
+				return {
+					message = localize("k_balanced"),
+					colour = { 0.8, 0.45, 0.85, 1 },
+				}
 			end
-			update_hand_text({ delay = 0 }, { mult = mult, chips = hand_chips })
-			return {
-				message = localize("k_balanced"),
-				colour = { 0.8, 0.45, 0.85, 1 },
-			}
 		end
 	end,
 }

--- a/Items/EpicJokers.lua
+++ b/Items/EpicJokers.lua
@@ -117,7 +117,7 @@ local sync_catalyst = {
 	calculate = function(self, card, context)
 		if context.cardarea == G.jokers and not context.before and not context.after then
 			local tot = hand_chips + mult
-			if not (type(tot) == "number") then -- Adding Guard clause to protect against unalowed hands
+			if not debuffed_hand then -- Adding Guard clause to protect against unallowed hands
 				if not tot.array or #tot.array < 2 or tot.array[2] < 2 then --below eXeY notation
 					hand_chips = mod_chips(math.floor(tot / 2))
 					mult = mod_mult(math.floor(tot / 2))


### PR DESCRIPTION
Added a guard wrapper around the calculations on Sync to prevent it from treating normal numbers as omega nums