### PR TITLE
Update Misc.lua

### DIFF
--- a/Items/Misc.lua
+++ b/Items/Misc.lua
@@ -819,9 +819,7 @@ local glass_edition = {
 				G.E_MANAGER:add_event(Event({
 					trigger = "after",
 					func = function()
-						if not card.shattered then
-							card:shatter()
-						end
+						card:shatter()
 						return true
 					end,
 				}))


### PR DESCRIPTION
Fixes a bug, that makes it so when fragile and glass are on one card and both trigger, the glass trigger blocks fragile from shattering it and the fragile trigger blocks grass from shattering it, causing the card to stay on the screen and softlocking the game because you aren't able to play hands anymore.