### PR TITLE
Changes cry_curse to cry_curse_sob

### DIFF
--- a/Items/EpicJokers.lua
+++ b/Items/EpicJokers.lua
@@ -684,10 +684,10 @@ local caramel = {
 	end,
 }
 --this has to be the most spaghetti code in cryptid
-local curse = {
+local curse_sob = {
 	object_type = "Joker",
-	name = "cry_curse",
-	key = "curse",
+	name = "cry_curse_sob",
+	key = "curse_sob",
 	pos = { x = 1, y = 1 },
 	rarity = "cry_epic",
 	cost = 9,
@@ -1381,7 +1381,7 @@ return {
 		oldcandy,
 		circus,
 		caramel,
-		curse,
+		curse_sob,
 		bonusjoker,
 		multjoker,
 		goldjoker,

--- a/localization/de.lua
+++ b/localization/de.lua
@@ -765,7 +765,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Schluchz",
                 text = {
                     "{C:edition,E:1}du kannst nicht{} {C:cry_ascendant,E:1}rennen...{}",

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -767,7 +767,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Sob",
                 text = {
                     "{C:edition,E:1}you cannot{} {C:cry_ascendant,E:1}run...{}",

--- a/localization/en_ES.lua
+++ b/localization/en_ES.lua
@@ -767,7 +767,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Sob",
                 text = {
                     "{C:edition,E:1}you cannot{} {C:cry_ascendant,E:1}run...{}",

--- a/localization/es_419.lua
+++ b/localization/es_419.lua
@@ -767,7 +767,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Sob",
                 text = {
                     "{C:edition,E:1}you cannot{} {C:cry_ascendant,E:1}run...{}",

--- a/localization/fr.lua
+++ b/localization/fr.lua
@@ -793,7 +793,7 @@ return {
                     "{C:chips}+#1#{} Jetons",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Pleure",
                 text = {
                     "{C:edition,E:1}tu ne peux pas {} {C:cry_ascendant,E:1}t'enfuir...{}",

--- a/localization/id.lua
+++ b/localization/id.lua
@@ -767,7 +767,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Sob",
                 text = {
                     "{C:edition,E:1}you cannot{} {C:cry_ascendant,E:1}run...{}",

--- a/localization/ja.lua
+++ b/localization/ja.lua
@@ -767,7 +767,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob_sob = {
                 name = "Sob",
                 text = {
                     "{C:edition,E:1}you cannot{} {C:cry_ascendant,E:1}run...{}",

--- a/localization/ko.lua
+++ b/localization/ko.lua
@@ -767,7 +767,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Sob",
                 text = {
                     "{C:edition,E:1}you cannot{} {C:cry_ascendant,E:1}run...{}",

--- a/localization/nl.lua
+++ b/localization/nl.lua
@@ -770,7 +770,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Sob",
                 text = {
                     "{C:edition,E:1}you cannot{} {C:cry_ascendant,E:1}run...{}",

--- a/localization/pl.lua
+++ b/localization/pl.lua
@@ -767,7 +767,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Sob",
                 text = {
                     "{C:edition,E:1}you cannot{} {C:cry_ascendant,E:1}run...{}",

--- a/localization/pt_BR.lua
+++ b/localization/pt_BR.lua
@@ -767,7 +767,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Sob",
                 text = {
                     "{C:edition,E:1}you cannot{} {C:cry_ascendant,E:1}run...{}",

--- a/localization/ru.lua
+++ b/localization/ru.lua
@@ -796,7 +796,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Sob",
                 text = {
                     "{C:edition,E:1}you cannot{} {C:cry_ascendant,E:1}run...{}",

--- a/localization/zh_CN.lua
+++ b/localization/zh_CN.lua
@@ -1067,7 +1067,7 @@ return {
                     "{C:chips}+#1#{} 筹码"
                 }
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "啜泣",
                 text = {
                     "{C:edition,E:1}你无法{} {C:cry_ascendant,E:1}逃跑...{}",

--- a/localization/zh_TW.lua
+++ b/localization/zh_TW.lua
@@ -767,7 +767,7 @@ return {
                     "{C:chips}+#1#{} Chips",
                 },
             },
-            j_cry_curse = {
+            j_cry_curse_sob = {
                 name = "Sob",
                 text = {
                     "{C:edition,E:1}you cannot{} {C:cry_ascendant,E:1}run...{}",


### PR DESCRIPTION
Seems like the new aditions will be adding other
cursed jokers to cryptid so changing sob from
cry_curse to cry_curse_sob will free up the name
and make sob just a tiny bit less cursed in the
code (not that it still isn't)