### PR TITLE
Fix: Food joker not checking for ban and sync crash v2?

### DIFF
--- a/Cryptid.lua
+++ b/Cryptid.lua
@@ -2891,7 +2891,14 @@ end
 for i = 1, #jokers do
 	Cryptid.food[#Cryptid.food+1] = jokers[i]
 end
-
+function Cryptid.get_food(seed)
+	local food_key = nil
+	for _=1,#Cryptid.food do
+		food_key = pseudorandom_element(Cryptid.food, pseudoseed(seed))
+		if not(food_key and  G.GAME.banned_keys[food_key] ) then return food_key  end
+	end
+	return "j_joker" -- 
+end
 SMODS.Sound({
 	key = "meow1",
 	path = "meow1.ogg",

--- a/Cryptid.lua
+++ b/Cryptid.lua
@@ -2892,12 +2892,13 @@ for i = 1, #jokers do
 	Cryptid.food[#Cryptid.food+1] = jokers[i]
 end
 function Cryptid.get_food(seed)
-	local food_key = nil
-	for _=1,#Cryptid.food do
-		food_key = pseudorandom_element(Cryptid.food, pseudoseed(seed))
-		if not(food_key and  G.GAME.banned_keys[food_key] ) then return food_key  end
+	local food_keys = nil
+	for k in Cryptid.food do
+		if not G.GAME.banned_keys[k] then
+			food_keys.insert(k)
+		end
 	end
-	return "j_joker" -- 
+	return pseudorandom_element(food_keys, pseudoseed(seed))
 end
 SMODS.Sound({
 	key = "meow1",

--- a/Items/CodeCards.lua
+++ b/Items/CodeCards.lua
@@ -867,7 +867,7 @@ local spaghetti = {
 			nil,
 			nil,
 			nil,
-			pseudorandom_element(Cryptid.food, pseudoseed("cry_spaghetti"))
+			Cryptid.get_food("cry_spaghetti")
 		)
 		card:set_edition({
 			cry_glitched = true,

--- a/Items/EpicJokers.lua
+++ b/Items/EpicJokers.lua
@@ -148,9 +148,10 @@ local sync_catalyst = {
 	blueprint_compat = true,
 	atlas = "atlasepic",
 	calculate = function(self, card, context)
-		if context.cardarea == G.jokers and not context.before and not context.after then
+		if context.cardarea == G.jokers and not context.before
+		 and not context.after and not context.debuffed_hand
+		  and hand_chips and mult then
 			local tot = hand_chips + mult
-			if not context.debuffed_hand then -- Adding Guard clause to protect against unallowed hands
 				if not tot.array or #tot.array < 2 or tot.array[2] < 2 then --below eXeY notation
 					hand_chips = mod_chips(math.floor(tot / 2))
 					mult = mod_mult(math.floor(tot / 2))
@@ -169,8 +170,7 @@ local sync_catalyst = {
 					colour = { 0.8, 0.45, 0.85, 1 },
 				}
 			end
-		end
-	end,
+		end,
 	cry_credits = {
 		idea = {
 			"Project666"

--- a/Items/Spooky.lua
+++ b/Items/Spooky.lua
@@ -81,7 +81,7 @@ local wrapped = {
 					nil,
 					nil,
 					nil,
-					pseudorandom_element(Cryptid.food, pseudoseed("cry_wrapped"))
+					Cryptid.get_food("cry_wrapped")
 				)
 				card:add_to_deck()
 				G.jokers:emplace(card)

--- a/Items/Tags.lua
+++ b/Items/Tags.lua
@@ -750,7 +750,7 @@ local gourmand = {
 				nil,
 				nil,
 				nil,
-				pseudorandom_element(Cryptid.food, pseudoseed("cry_gourmand_tag"))
+				Cryptid.get_food("cry_gourmand_tag")
 			)
 			create_shop_card_ui(card, "Joker", context.area)
 			card.states.visible = false


### PR DESCRIPTION
adds a function for selecting a food joker that respects the banned cards