### PR TITLE
chocolate dice end event on leave deck

### DIFF
--- a/Items/Spooky.lua
+++ b/Items/Spooky.lua
@@ -126,6 +126,12 @@ local choco_dice = {
 			}
 		end
 	end,
+	remove_from_deck = function(self, card, form_debuff)
+		if not form_debuff then
+			SMODS.Events["ev_cry_choco"..card.ability.extra.roll]:finish()
+		end
+		
+	end,
 }
 local choco_base_event = {
 	object_type = "Event",


### PR DESCRIPTION
Prevents joker effect from permanently persisting after it has been removed