### PR TITLE
fix: semicolon losing

### DIFF
--- a/lovely/Code.toml
+++ b/lovely/Code.toml
@@ -69,21 +69,15 @@ match_indent = true
 
 # Semicolon - don't lose
 [[patches]]
-[patches.regex]
+[patches.pattern]
 target = "functions/state_events.lua"
-pattern = '''game_over = false
-(?<indent>[\t ]*)end
-[\t ]*for i = 1, #G.jokers.cards do'''
-position = 'at'
-# match_indent = true
-line_prepend = '$indent'
+pattern = '''G.RESET_JIGGLES = true'''
+position = 'after'
+match_indent = true
 payload = '''
-game_over = false
-end
-if G.GAME.current_round.semicolon and game_over then
+if G.GAME.current_round.semicolon then
     game_over = false
 end
-for i = 1, #G.jokers.cards do
 '''
 
 # Semicolon - end screen text


### PR DESCRIPTION
Fixes a patch conflict with cryptid causing semicolon's patch to not work. I think when I wrote this originally I thought it had to run before the win check, but it very much doesn't, do I can now use something much less likely to be messed with.