### PR TITLE
Remove realer_card_limit (handsize <= decksize limit), fix card spacing instead

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -107,24 +107,17 @@ position = "at"
 payload = "{card_limit = 1e308, type = 'discard'})"
 match_indent = true
 
-# Max out hand size at deck size
+# When hand size exceeds deck size, space the cards as if the hand size was equal to the deck size
 [[patches]]
 [patches.pattern]
 target = "cardarea.lua"
-pattern = "self.config.real_card_limit = (self.config.real_card_limit or self.config.card_limit) + delta"
-position = "at"
+pattern = "function CardArea:align_cards()"
+position = "after"
 payload = '''
-self.config.realer_card_limit = (self.config.realer_card_limit or self.config.real_card_limit or self.config.card_limit) + delta
-self.config.real_card_limit = self ~= G.hand and self.config.realer_card_limit or math.min((G.deck and G.deck.config.card_limit or 52), self.config.realer_card_limit)
+    if self.config.type == 'hand' then
+        self.config.temp_limit = math.min(self.config.card_limit, #G.playing_cards)
+    end
 '''
-match_indent = true
-
-[[patches]]
-[patches.pattern]
-target = "cardarea.lua"
-pattern = "self.config.card_limit = math.max(0, self.config.real_card_limit)"
-position = "at"
-payload = "self.config.card_limit = math.max(0, self.config.real_card_limit)"
 match_indent = true
 
 # Crash fix


### PR DESCRIPTION
The introduction of "realer_card_limit" conflicts with Steammodded's implementation of negative playing cards, resulting in bugs when change_size() is called during a round while negative cards are in hand (for instance, obtaining or selling a joker like Troubador/Merry Andy).

I'm assuming that realer_card_limit was primarily introduced to deal with situations where extreme hand sizes resulted in the cards becoming extremely scrunched up, to the point where they were impossible to click, hence the introduction of realer_card_limit to try and limit the size under normal conditions.

Instead of using realer_card_limit, this change just fixes the cardarea alignment itself to align cards as if the hand size were capped at the deck size.