### PR TITLE
old bp dying causes blueprint corruption

### DIFF
--- a/Items/MiscJokers.lua
+++ b/Items/MiscJokers.lua
@@ -5377,7 +5377,7 @@ local oldblueprint = {
 								G.jokers:remove_card(card)
 								card:remove()
 								card = nil
-								G.GAME.oldbpfactor = (G.GAME.oldbpfactor or 1)*3
+								if G.P_CENTERS["j_blueprint"].unlocked then G.GAME.oldbpfactor = (G.GAME.oldbpfactor or 1)*3 end
 								return true
 							end,
 						}))

--- a/Items/MiscJokers.lua
+++ b/Items/MiscJokers.lua
@@ -5345,7 +5345,7 @@ local oldblueprint = {
 	pos = { x = 2, y = 1 },
 	config = { extra = { odds = 4 } },
 	rarity = 1,
-	cost = 5,
+	cost = 6,
 	order = 83,
 	loc_vars = function(self, info_queue, center)
 		return { vars = { "" .. (G.GAME and G.GAME.probabilities.normal or 1), center.ability.extra.odds } }
@@ -5377,6 +5377,7 @@ local oldblueprint = {
 								G.jokers:remove_card(card)
 								card:remove()
 								card = nil
+								G.GAME.oldbpfactor = (G.GAME.oldbpfactor or 1)*3
 								return true
 							end,
 						}))

--- a/lovely/Misc.toml
+++ b/lovely/Misc.toml
@@ -441,3 +441,31 @@ if G.GAME.modifiers.cry_forced_draw_amount and (G.GAME.current_round.hands_playe
 end
 '''
 match_indent = true
+
+# adds oldbp blueprint corruption
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = 'if _pool_size == 0 then'
+position = "before"
+payload = '''
+if G.GAME.oldbpfactor and G.GAME.oldbpfactor >= 2 then
+	if _type == 'Joker' and (_rarity == nil or type(_rarity) ~= "string") and not _legendary and not (G.GAME.used_jokers["j_blueprint"] and not next(find_joker("Showman"))) then
+		for i = 1, math.floor(G.GAME.oldbpfactor - 1) do
+			_pool[#_pool + 1] = "j_blueprint"
+		end
+	end
+end
+'''
+match_indent = true
+
+# end of shop decrement
+[[patches]]
+[patches.pattern]
+target = "functions/button_callbacks.lua"
+pattern = 'G.SHOP_SIGN.alignment.offset.y = -15'
+position = "after"
+payload = '''
+if G.GAME.oldbpfactor then G.GAME.oldbpfactor = math.max(G.GAME.oldbpfactor - G.GAME.oldbpfactor/8, 1) end
+'''
+match_indent = true


### PR DESCRIPTION
this was an easter egg mechanic originally intended by linus, although it's not really a perfect representation of it

should affect commons, uncommons, and rares (this means sources of common/uncommons could spawn blueprints with this active, but not other rarities)

feel free to tweak the numbers around or move it, i was just messing with it
i thought multiplicative growth could be fun since it would be very difficult to proc it, but maybe it's too steep