### PR TITLE
Double sided but with out jank

### DIFF
--- a/Items/Misc.lua
+++ b/Items/Misc.lua
@@ -1742,7 +1742,7 @@ return {
 			if not self.dbl_side then
 				self.dbl_side = cry_deep_copy(self)
 				self.dbl_side:set_ability(G.P_CENTERS.c_base)
-				self.dbl_side:set_base(G.P_CARDS.empty)
+				-- self.dbl_side:set_base(G.P_CARDS.empty) -- RIGHT HERE THIS RIGHT HERE THATS YOUR DAM CULPRIT
 				if self.area == G.hand then
 					self.dbl_side.config.center = cry_deep_copy(self.dbl_side.config.center)
 					self.dbl_side.config.center.no_rank = true

--- a/Items/Misc.lua
+++ b/Items/Misc.lua
@@ -609,6 +609,7 @@ local noisy = {
 									.. (
 										G.deck
 											and G.deck.cards[1]
+											and G.deck.cards[#G.deck.cards].base.suit
 											and G.deck.cards[#G.deck.cards].base.suit:sub(1, 1)
 										or "D"
 									),


### PR DESCRIPTION
The reason for a lot of the major crash reports at the minute was this single line in [Misc]( Items/Misc.lua) that set the base of the back side to nil. I'm sure the was meant to be an "Empty" card made at some point but it's not present and causes double sidded to break everything