### PR TITLE
Fix stakes not unlocking

### DIFF
--- a/Items/Stakes.lua
+++ b/Items/Stakes.lua
@@ -5,6 +5,7 @@ local pink = {
 	pos = { x = 0, y = 0 },
 	atlas = "stake",
 	applied_stakes = { "gold" },
+	prefix_config = { applied_stakes = { mod = false } },
 	modifiers = function()
 		G.GAME.modifiers.scaling = (G.GAME.modifiers.scaling or 1) + 1
 	end,


### PR DESCRIPTION
one line change :skull:
technically the other applied_stakes should be changed to remove the prefix as well, but steamodded recognizes the already present prefix so it's fine