### PR TITLE
make vanilla Wee Joker and cryptid Weebonacci visually scale

### DIFF
--- a/Cryptid.lua
+++ b/Cryptid.lua
@@ -1151,6 +1151,36 @@ function Card:calculate_joker(context)
 	return ret, trig
 end
 
+function Card:resize_wee_joker()
+    -- taken from the base game
+    local wee_scale = 0.7
+
+    -- there's several places where we need to calculate a wee joker that do
+    -- not yet have abilities set up properly
+    print(self.config.center_key)
+    local value = 0
+    if self.ability ~= nil then
+        if self.ability.extra ~= nil then
+            if self.config.center_key == "j_wee" then
+                value = self.ability.extra.value
+            elseif self.config.center_key == "j_cry_wee_fib" then
+                value = self.ability.extra.mult
+            end
+        end
+    end
+    value = value or 0
+
+    local scale = 1
+    if scale > 0.07 then
+        local scale_pow = math.log10(math.max(100, value)) - 1
+        scale = math.max(0.07, wee_scale ^ scale_pow)
+    end
+    -- this looks like it's counting wee_scale twice but scale is adjusted
+    -- so that it is a modifier on the normal small scale so this is correct
+    self.T.w = G.CARD_W * wee_scale * scale
+    self.T.h = G.CARD_H * wee_scale * scale
+end
+
 function exponentia_scale_mod(self, orig_scale_scale, orig_scale_base, new_scale_base)
 	local jkr = self
 	local dbl_info = G.GAME.cry_double_scale[jkr.sort_id]

--- a/Items/MiscJokers.lua
+++ b/Items/MiscJokers.lua
@@ -300,6 +300,7 @@ local wee_fib = {
 			local rank = SMODS.Ranks[context.other_card.base.value].key
 			if rank == "Ace" or rank == "2" or rank == "3" or rank == "5" or rank == "8" then
 				card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.mult_mod
+				card:resize_wee_joker()
 
 				return {
 					extra = { focus = card, message = localize("k_upgrade_ex") },

--- a/lovely/ResizedJokers.toml
+++ b/lovely/ResizedJokers.toml
@@ -10,7 +10,7 @@ target = "card.lua"
 pattern = 'if center.name == "Wee Joker" and (center.discovered or self.bypass_discovery_center) then'
 position = "before"
 payload = '''
-if (center.name == "cry-Wee Fibonacci" or center.name == "cry-reverse") and (center.discovered or self.bypass_discovery_center) then 
+if center.name == "cry-reverse" and (center.discovered or self.bypass_discovery_center) then
     H = H*0.7
     W = W*0.7
     self.T.h = H
@@ -61,8 +61,37 @@ end
 '''
 match_indent = true
 
+# wee joker resizing
+# replaces base game wee joker size and adds cryptid weebonacci
+[[patches]]
+[patches.regex]
+target = "card.lua"
+pattern = 'if center\.name == "Wee Joker" and \(center\.discovered or self\.bypass_discovery_center\) then(.|\r|\n)*?end'
+position = "at"
+payload = '''
+if (center.name == "Wee Joker" or center.name == "cry-Wee Fibonacci") and (center.discovered or self.bypass_discovery_center) then
+    self:resize_wee_joker()
+end
+'''
+match_indent = true
 
-# Wee Fibonacci rendering
+# wee joker resizing
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Wee Joker' and
+    context.other_card:get_id() == 2 and not context.blueprint then
+        self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
+'''
+position = "after"
+payload = '''
+        self:resize_wee_joker()
+'''
+match_indent = true
+
+
+# non-standard joker size rendering
 [[patches]]
 [patches.pattern]
 target = "card.lua"
@@ -91,14 +120,14 @@ end
 '''
 match_indent = true
 
-# Cube rendering
+# non-standard joker size rendering
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = 'elseif self.config.center.name == "Wee Joker" then'
 position = "before"
 payload = '''
-elseif self.config.center.name == "cry-Wee Fibonacci" or self.config.center.name == "cry-reverse" then 
+elseif self.config.center.name == "cry-reverse" then 
     self.T.h = H*scale*0.7*scale
     self.T.w = W*scale*0.7*scale
 elseif self.config.center.name == "cry-biggestm" then 


### PR DESCRIPTION
i came up with this idea a few days ago at like 5am and implemented it and it was cute, so i polished it a bit and applied it to both vanilla and cryptid jokers

this will scale wee joker and weebonacci visually down to 7% of their initial size (to keep them usable), totaling a final scale of 4.9% (`0.07 * 0.7 = 0.049`) of a regular sized joker.

in the implementation i am not sure about the lovely patches, the regex is Probably Fine, but the detection of where to insert for wee joker seems flaky, is there a better way?