### PR TITLE
fixed compound interest with negative balance PLEASE REVIEW

### DIFF
--- a/Items/MiscJokers.lua
+++ b/Items/MiscJokers.lua
@@ -853,17 +853,20 @@ local compound_interest = {
 		return { vars = { center.ability.extra.percent, center.ability.extra.percent_mod } }
 	end,
 	calc_dollar_bonus = function(self, card)
-		local bonus = math.max(0, math.floor(0.01 * card.ability.extra.percent * (G.GAME.dollars or 1)))
-		local old = card.ability.extra.percent
-		card.ability.extra.percent = card.ability.extra.percent + card.ability.extra.percent_mod
-		compound_interest_scale_mod(card, card.ability.extra.percent_mod, old, card.ability.extra.percent)
-		if bonus > 0 then
-			if G.GAME.dollars > 1e10 then
-				return 1
-			else
-				return bonus
+		if G.GAME.dollars > 0 then
+			local bonus = math.max(0, math.floor(0.01 * card.ability.extra.percent * (G.GAME.dollars or 1)))
+			local old = card.ability.extra.percent
+			card.ability.extra.percent = card.ability.extra.percent + card.ability.extra.percent_mod
+			compound_interest_scale_mod(card, card.ability.extra.percent_mod, old, card.ability.extra.percent)
+			if bonus > 0 then
+				if G.GAME.dollars > 1e10 then
+					return 1
+				else
+					return bonus
+				end
 			end
-		end
+		else 
+			return 0
 	end,
 	cry_credits = {
 		idea = {

--- a/Items/MiscJokers.lua
+++ b/Items/MiscJokers.lua
@@ -867,6 +867,7 @@ local compound_interest = {
 			end
 		else 
 			return 0
+		end
 	end,
 	cry_credits = {
 		idea = {


### PR DESCRIPTION
previously the "Compound Interest" joker would cause a crash when balance was a negative number (thanks to credit card). A fringe case, but still not ideal.
Hopefully now it just does nothing, rather than break the game. 