### PR TITLE
Quick LSP Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# LSP setting files (add more if applicable)
+.vscode/*
+.luarc.json

--- a/items/code.lua
+++ b/items/code.lua
@@ -1207,7 +1207,7 @@ local hooked = {
 					var = localize({ type = "name_text", set = "Joker", key = G.jokers.cards[i].config.center.key })
 				end
 			end
-			var = var or "[no joker found - " .. (card.hook_id or "nil") .. "]"
+			var = var or ("[no joker found - " .. (card.hook_id or "nil") .. "]")
 		end
 		return { vars = { var or "hooked Joker" } }
 	end,

--- a/items/epic.lua
+++ b/items/epic.lua
@@ -1724,7 +1724,7 @@ local fleshpanopticon = {
 			card.gone = false
 			G.GAME.blind.chips = G.GAME.blind.chips * card.ability.extra.boss_size
 			G.GAME.blind.chip_text = number_format(G.GAME.blind.chips)
-			G.HUD_blind:recalculate(true)
+			G.HUD_blind:recalculate()
 			G.E_MANAGER:add_event(Event({
 				func = function()
 					G.E_MANAGER:add_event(Event({

--- a/items/misc.lua
+++ b/items/misc.lua
@@ -247,7 +247,7 @@ local oversat = {
 				return cry_misprintize_val(val, {
 					min = 2,
 					max = 2,
-				}, is_card_big(card), true)
+				}, is_card_big(card))
 			end)
 		end
 	end,
@@ -347,7 +347,7 @@ local glitched = {
 				return cry_misprintize_val(val, {
 					min = 0.1 * (G.GAME.modifiers.cry_misprint_min or 1),
 					max = 10 * (G.GAME.modifiers.cry_misprint_max or 1),
-				}, is_card_big(card), true)
+				}, is_card_big(card))
 			end)
 		end
 	end,

--- a/items/misc_joker.lua
+++ b/items/misc_joker.lua
@@ -1498,7 +1498,6 @@ local fspinner = {
 	order = 77,
 	blueprint_compat = true,
 	perishable_compat = false,
-	atlas = "fspinner",
 	calculate = function(self, card, context)
 		if context.before and not context.blueprint then
 			local play_more_than = (G.GAME.hands[context.scoring_name].played or 0)

--- a/lib/ascended.lua
+++ b/lib/ascended.lua
@@ -155,7 +155,7 @@ function cry_ascend(num) -- edit this function at your leisure
 	else
 		return math.max(
 			num,
-			num * ((1.25 + (0.05 * (G.GAME.sunnumber or 0))) ^ G.GAME.current_round.current_hand.cry_asc_num or 0)
+			num * ((1.25 + (0.05 * (G.GAME.sunnumber or 0))) ^ (G.GAME.current_round.current_hand.cry_asc_num or 0))
 		)
 	end
 end

--- a/lib/gameset.lua
+++ b/lib/gameset.lua
@@ -936,11 +936,13 @@ end
 ---- CARD ENABLING SYSTEM ----
 ------------------------------
 
+---@type fun(self: SMODS.GameObject|table, reason: table)?
 SMODS.GameObject._disable = function(self, reason)
 	if not self.cry_disabled then
 		self.cry_disabled = reason or { type = "manual" } --used to display more information that can be used later
 	end
 end
+---@type fun(self: SMODS.GameObject|table)?
 SMODS.GameObject.enable = function(self)
 	if self.cry_disabled then
 		self.cry_disabled = nil
@@ -950,6 +952,7 @@ end
 -- Note: For custom pools, these only support Center.pools, not ObjectType.cards
 -- That could cause issues with mod compat in the future
 -- Potential improvement: automatic pool detection from gamesets?
+---@type fun(self: SMODS.Center|table, reason: table)?
 SMODS.Center._disable = function(self, reason)
 	if not self.cry_disabled then
 		self.cry_disabled = reason or { type = "manual" } --used to display more information that can be used later
@@ -960,6 +963,7 @@ SMODS.Center._disable = function(self, reason)
 		G.P_CENTERS[self.key] = nil
 	end
 end
+---@type fun(self: SMODS.Center|table)?
 SMODS.Center.enable = function(self)
 	if self.cry_disabled then
 		self.cry_disabled = nil
@@ -970,6 +974,8 @@ SMODS.Center.enable = function(self)
 		end
 	end
 end
+
+---@type fun(self: SMODS.Joker|table)?
 SMODS.Joker.enable = function(self)
 	if self.cry_disabled then
 		SMODS.Center.enable(self)
@@ -980,6 +986,7 @@ SMODS.Joker.enable = function(self)
 		end
 	end
 end
+---@type fun(self: SMODS.Joker|table, reason: table)?
 SMODS.Joker._disable = function(self, reason)
 	if not self.cry_disabled then
 		SMODS.Center._disable(self, reason)
@@ -990,6 +997,7 @@ SMODS.Joker._disable = function(self, reason)
 		end
 	end
 end
+---@type fun(self: SMODS.Joker|table, rarity: string|number)?
 SMODS.Joker.set_rarity = function(self, rarity)
 	SMODS.remove_pool(G.P_JOKER_RARITY_POOLS[self.rarity], self.key)
 	self.rarity = rarity
@@ -1000,12 +1008,14 @@ SMODS.Joker.set_rarity = function(self, rarity)
 	end
 end
 
+---@type fun(self: SMODS.Consumable|table)?
 SMODS.Consumable.enable = function(self)
 	if self.cry_disabled then
 		SMODS.Center.enable(self)
 		SMODS.insert_pool(G.P_CENTER_POOLS["Consumeables"], self)
 	end
 end
+---@type fun(self: SMODS.Consumable|table, reason: table)?
 SMODS.Consumable._disable = function(self, reason)
 	if not self.cry_disabled then
 		SMODS.Center._disable(self, reason)
@@ -1013,6 +1023,7 @@ SMODS.Consumable._disable = function(self, reason)
 	end
 end
 
+---@type fun(self: SMODS.Tag|table, reason: table)?
 SMODS.Tag._disable = function(self, reason)
 	if not self.cry_disabled then
 		self.cry_disabled = reason or { type = "manual" } --used to display more information that can be used later
@@ -1020,6 +1031,7 @@ SMODS.Tag._disable = function(self, reason)
 		G.P_TAGS[self.key] = nil
 	end
 end
+---@type fun(self: SMODS.Tag|table)?
 SMODS.Tag.enable = function(self)
 	if self.cry_disabled then
 		self.cry_disabled = nil
@@ -1028,12 +1040,14 @@ SMODS.Tag.enable = function(self)
 	end
 end
 
+---@type fun(self: SMODS.Blind|table, reason: table)?
 SMODS.Blind._disable = function(self, reason)
 	if not self.cry_disabled then
 		self.cry_disabled = reason or { type = "manual" } --used to display more information that can be used later
 		G.P_BLINDS[self.key] = nil
 	end
 end
+---@type fun(self: SMODS.Blind|table)?
 SMODS.Blind.enable = function(self)
 	if self.cry_disabled then
 		self.cry_disabled = nil
@@ -1042,12 +1056,14 @@ SMODS.Blind.enable = function(self)
 end
 
 --Removing seals from the center table causes issues
+---@type fun(self: SMODS.Seal|table, reason: table)?
 SMODS.Seal._disable = function(self, reason)
 	if not self.cry_disabled then
 		self.cry_disabled = reason or { type = "manual" } --used to display more information that can be used later
 		SMODS.remove_pool(G.P_CENTER_POOLS[self.set], self.key)
 	end
 end
+---@type fun(self: SMODS.Seal|table)?
 SMODS.Seal.enable = function(self)
 	if self.cry_disabled then
 		self.cry_disabled = nil
@@ -1056,6 +1072,7 @@ SMODS.Seal.enable = function(self)
 end
 
 --Removing editions from the center table causes issues, so instead we make them unable to spawn naturally
+---@type fun(self: SMODS.Seal|table, reason: table)?
 SMODS.Edition._disable = function(self, reason)
 	if not self.cry_disabled then
 		self.cry_disabled = reason or { type = "manual" } --used to display more information that can be used later
@@ -1066,6 +1083,7 @@ SMODS.Edition._disable = function(self, reason)
 		end
 	end
 end
+---@type fun(self: SMODS.Seal|table)?
 SMODS.Edition.enable = function(self)
 	if self.cry_disabled then
 		self.cry_disabled = nil

--- a/lib/misc.lua
+++ b/lib/misc.lua
@@ -563,7 +563,7 @@ function is_card_big(joker)
 end
 
 --Utility function to check things without erroring
----@param t table 
+---@param t table
 ---@param ... any
 ---@return table|false
 function safe_get(t, ...)

--- a/lib/misc.lua
+++ b/lib/misc.lua
@@ -563,6 +563,9 @@ function is_card_big(joker)
 end
 
 --Utility function to check things without erroring
+---@param t table 
+---@param ... any
+---@return table|false
 function safe_get(t, ...)
 	local current = t
 	for _, k in ipairs({ ... }) do

--- a/localization/id.lua
+++ b/localization/id.lua
@@ -3083,7 +3083,7 @@ return {
 			k_disable_music = "Disable Music",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 
 			cry_notif_jimball_1 = "Jimball",
 			cry_notif_jimball_2 = "Copyright Notice",
@@ -3113,7 +3113,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {

--- a/localization/id.lua
+++ b/localization/id.lua
@@ -3083,7 +3083,7 @@ return {
 			k_disable_music = "Disable Music",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 
 			cry_notif_jimball_1 = "Jimball",
 			cry_notif_jimball_2 = "Copyright Notice",
@@ -3113,7 +3113,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {

--- a/localization/ja.lua
+++ b/localization/ja.lua
@@ -3083,7 +3083,7 @@ return {
 			k_disable_music = "Disable Music",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 
 			cry_notif_jimball_1 = "Jimball",
 			cry_notif_jimball_2 = "Copyright Notice",
@@ -3113,7 +3113,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {

--- a/localization/ja.lua
+++ b/localization/ja.lua
@@ -3083,7 +3083,7 @@ return {
 			k_disable_music = "Disable Music",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 
 			cry_notif_jimball_1 = "Jimball",
 			cry_notif_jimball_2 = "Copyright Notice",
@@ -3113,7 +3113,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {

--- a/localization/ko.lua
+++ b/localization/ko.lua
@@ -3083,7 +3083,7 @@ return {
 			k_disable_music = "Disable Music",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 
 			cry_notif_jimball_1 = "Jimball",
 			cry_notif_jimball_2 = "Copyright Notice",
@@ -3113,7 +3113,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {

--- a/localization/ko.lua
+++ b/localization/ko.lua
@@ -3083,7 +3083,7 @@ return {
 			k_disable_music = "Disable Music",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 
 			cry_notif_jimball_1 = "Jimball",
 			cry_notif_jimball_2 = "Copyright Notice",
@@ -3113,7 +3113,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {

--- a/localization/pt_BR.lua
+++ b/localization/pt_BR.lua
@@ -3083,7 +3083,7 @@ return {
 			k_disable_music = "Disable Music",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 
 			cry_notif_jimball_1 = "Jimball",
 			cry_notif_jimball_2 = "Copyright Notice",
@@ -3113,7 +3113,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {

--- a/localization/pt_BR.lua
+++ b/localization/pt_BR.lua
@@ -3083,7 +3083,7 @@ return {
 			k_disable_music = "Disable Music",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 
 			cry_notif_jimball_1 = "Jimball",
 			cry_notif_jimball_2 = "Copyright Notice",
@@ -3113,7 +3113,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {

--- a/localization/ru.lua
+++ b/localization/ru.lua
@@ -3114,7 +3114,7 @@ return {
 			cry_inactive = "Inactive",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 		},
 		labels = {
 			food_jokers = "Food Jokers",
@@ -3138,7 +3138,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {

--- a/localization/ru.lua
+++ b/localization/ru.lua
@@ -3114,7 +3114,7 @@ return {
 			cry_inactive = "Inactive",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 		},
 		labels = {
 			food_jokers = "Food Jokers",
@@ -3138,7 +3138,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {

--- a/localization/zh_TW.lua
+++ b/localization/zh_TW.lua
@@ -3083,7 +3083,7 @@ return {
 			k_disable_music = "Disable Music",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 
 			cry_notif_jimball_1 = "Jimball",
 			cry_notif_jimball_2 = "Copyright Notice",
@@ -3113,7 +3113,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_exotic ="Exotic",
+			k_cry_exotic = "Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {

--- a/localization/zh_TW.lua
+++ b/localization/zh_TW.lua
@@ -3083,7 +3083,7 @@ return {
 			k_disable_music = "Disable Music",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 
 			cry_notif_jimball_1 = "Jimball",
 			cry_notif_jimball_2 = "Copyright Notice",
@@ -3113,7 +3113,7 @@ return {
 			cry_oversat = "Oversaturated",
 
 			k_cry_epic = "Epic",
-			k_cry_epic = "Exotic",
+			k_cry_exotic ="Exotic",
 		},
 		rnj_loc_txts = {
 			stats = {


### PR DESCRIPTION
Deals with a bunch of LSP diagnosic warns that wouldn't already be muted (e.x. "redundant-parameter", "ambiguity-1", "missing-fields" etc.). Also adds `.gitignore` for two common ways of setting LSP settings. 
Also has a bugfix for that one whoops I made several months ago that nobody noticed. 