### PR TITLE
Clockwork Joker

### DIFF
--- a/items/epic.lua
+++ b/items/epic.lua
@@ -1897,6 +1897,110 @@ local jtron = {
 		code = { "candycanearter" },
 	},
 }
+local clockwork = { -- Retriggers steels every 2nd hand, scaling xmult every 3rd hand, negative chariot every 5th hand, stronger steels every 7th hand
+	object_type = "Joker",
+	dependencies = {
+		items = {
+			"set_cry_epic",
+		},
+	},
+	name = "cry-clockwork",
+	key = "clockwork",
+	pos = { x = 2, y = 0 },
+	config = { counters = { c1 = 0, c2 = 0, c3 = 0, c4 = 0 }, extra = { xmult = 1, xmult_mod = 0.5, steelenhc = 1, steel_mod = 0.2 } },
+	order = 135,
+	immutable = false,
+	rarity = "cry_epic",
+	cost = 12,
+	blueprint_compat = true,
+	atlas = "placeholders",
+	in_pool = function(self)
+		if not true then -- TODO: make it say "if deck has steel cards"
+			return false
+		end
+		return true
+	end,
+	loc_vars = function(self, info_queue, center)
+		return { vars = { center.ability.counters.c1, center.ability.counters.c2, center.ability.counters.c3, center.ability.counters.c4, center.ability.extra.xmult, center.ability.extra.xmult_mod, center.ability.extra.steelenhc, center.ability.extra.steel_mod } }
+	end,
+	calculate = function(self, card, context)
+		if
+			context.before and context.cardarea == G.jokers and not context.blueprint and not context.retrigger
+		then
+			if card.ability.counters.c1 >= 1 then
+				card.ability.counters.c1 = 0
+			else
+				card.ability.counters.c1 = card.ability.counters.c1 + 1
+			end
+			if card.ability.counters.c2 >= 2 then
+				card.ability.counters.c2 = 0
+				card.ability.extra.xmult = card.ability.extra.xmult + card.ability.extra.xmult_mod
+				return { message = "Upgrade!" }
+			else
+				card.ability.counters.c2 = card.ability.counters.c2 + 1
+			end
+			if card.ability.counters.c3 >= 4 then
+				card.ability.counters.c3 = 0
+				G.E_MANAGER:add_event(Event({
+					trigger = "after",
+					delay = 0.4,
+					func = function()
+						if G.consumeables.config.card_limit > #G.consumeables.cards then
+							play_sound("timpani")
+							local _card = create_card("Tarot", G.consumeables, nil, nil, nil, nil, "c_chariot", "clockwork")
+							_card:set_edition({ negative = true }, true)
+							_card:add_to_deck()
+							G.consumeables:emplace(_card)
+							card:juice_up(0.3, 0.5)
+						end
+						return true
+					end,
+				}))
+			else
+				card.ability.counters.c3 = card.ability.counters.c3 + 1
+			end
+			if card.ability.counters.c4 >= 6 then
+				card.ability.counters.c4 = 0
+				card.ability.extra.steelenhc = card.ability.extra.steelenhc + card.ability.extra.steel_mod
+				return { message = "Upgrade!" }
+			else
+				card.ability.counters.c4 = card.ability.counters.c4 + 1
+			end
+		end
+		if context.repetition and context.cardarea == G.play and card.ability.counters.c1 == 0 then -- effect 1
+			if context.other_card.ability.effect == "Steel Card" then
+				return {
+					message = localize("k_again_ex"),
+					repetitions = 1,
+					card = card,
+				}
+			end
+		end
+		if
+			context.joker_main and context.cardarea == G.jokers -- effect 2
+		then
+			return { xmult = card.ability.extra.xmult }
+		end
+		-- effect 3 handled above
+		if context.individual and context.cardarea == G.hand and context.other_card.ability.effect == "Steel Card" and card.ability.extra.steelenhc > 1 then -- effect 4
+			return { xmult = card.ability.extra.steelenhc }
+		end
+	end,
+	--[[add_to_deck = function(self, card, from_debuff) -- TODO: randomize starting positions by replacing randomize() with whatever function returns a proper int
+		card.ability.counters.c1 = randomize(c1) 0-1
+		card.ability.counters.c2 = randomize(c2) 0-2
+		card.ability.counters.c3 = randomize(c3) 0-4
+		card.ability.counters.c4 = randomize(c4) 0-6
+	end--]]
+	cry_credits = {
+		idea = {
+			"Nova and cassknows",
+		},
+		code = {
+			"Nova",
+		},
+	},
+}
 return {
 	name = "Epic Jokers",
 	items = {
@@ -1924,5 +2028,6 @@ return {
 		fleshpanopticon,
 		spectrogram,
 		jtron,
+		clockwork,
 	},
 }

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1109,6 +1109,16 @@ return {
 					"you {C:attention}click",
 				},
 			},
+	    		j_cry_clockwork = { -- make this better please
+				 name = "Clockwork Joker",
+				 text = {
+		                        "Every {C:attention}second{} {C:inactive}(#1#){} hand played retriggers all steel cards,",
+                                        "every {C:attention}third{} {C:inactive}(#2#){} hand played, this joker gains {C:mult}#6#x Mult{},",
+                                        "every {C:attention}fifth{} {C:inactive}(#3#){} hand played, create a Negative Chariot,",
+                                        "every {C:attention}seventh{} {C:inactive}(#4#){} hand played, Steel cards give an additional {C:mult}#8#x{} more {C:mult}Mult{}",
+                                        "{C:inactive}Currently gives #5#x Mult on trigger and #7#x Mult on Steel{}",
+                                },
+                        },
 			j_cry_CodeJoker = {
 				name = "Code Joker",
 				text = {


### PR DESCRIPTION
oh hey i figured out multiple commits

effect: has different effects based on hand, on every 2nd, 3rd, 5th and 7th hands (counted separately)
every second hand, retriggers played steel cards
every third hand, gains scaling xmult (currently x0.5, could be nerfed)
every fifth hand, creates a negative chariot
every seventh hand, steel cards give extra; think the way stardust works, the poly applies and then the increase applies afterwards, this is the same but for steel cards held in hand. starts at 1x and increases by 0.2x per trigger (could also be nerfed)

ideas: nova (me) and cassknows, discussion started https://discord.com/channels/1264429948970733782/1274103559113150629/1345315568601010227 (just scroll down)
code: nova (also me)

things left to do (that i can't):
make locs look better
add in_pool function for if you have steels
randomize starting counter values

optional maybe make the counters round so when they spawn w/ glitched, they auto round to nearest whole?