### PR TITLE
Galdur + CardSleeves compat

### DIFF
--- a/lib/ui.lua
+++ b/lib/ui.lua
@@ -8,7 +8,8 @@ SMODS.DrawStep({
 	order = 5,
 	func = function(self)
 		if Cryptid.safe_get(self, "area", "config", "type") == "deck" then
-			local currentBack = self.params.viewed_back and G.GAME.viewed_back or G.GAME.selected_back
+            -- following here is a horrendous mod compatability line
+			local currentBack = not self.params.galdur_selector and ((Galdur and Galdur.config.use and type(self.params.galdur_back) == 'table' and self.params.galdur_back) or type(self.params.viewed_back) == 'table' and self.params.viewed_back or (self.params.viewed_back and G.GAME.viewed_back or G.GAME.selected_back)) or Back(G.P_CENTERS['b_red'])
 			if currentBack.effect.config.cry_force_edition and not currentBack.effect.config.cry_antimatter then
 				if currentBack.effect.config.cry_force_edition_shader then
 					self.children.back:draw_shader(

--- a/lib/ui.lua
+++ b/lib/ui.lua
@@ -8,8 +8,12 @@ SMODS.DrawStep({
 	order = 5,
 	func = function(self)
 		if Cryptid.safe_get(self, "area", "config", "type") == "deck" then
-            -- following here is a horrendous mod compatability line
-			local currentBack = not self.params.galdur_selector and ((Galdur and Galdur.config.use and type(self.params.galdur_back) == 'table' and self.params.galdur_back) or type(self.params.viewed_back) == 'table' and self.params.viewed_back or (self.params.viewed_back and G.GAME.viewed_back or G.GAME.selected_back)) or Back(G.P_CENTERS['b_red'])
+			-- following here is a horrendous mod compatability line
+			local currentBack = not self.params.galdur_selector
+					and ((Galdur and Galdur.config.use and type(self.params.galdur_back) == "table" and self.params.galdur_back) or type(
+						self.params.viewed_back
+					) == "table" and self.params.viewed_back or (self.params.viewed_back and G.GAME.viewed_back or G.GAME.selected_back))
+				or Back(G.P_CENTERS["b_red"])
 			if currentBack.effect.config.cry_force_edition and not currentBack.effect.config.cry_antimatter then
 				if currentBack.effect.config.cry_force_edition_shader then
 					self.children.back:draw_shader(


### PR DESCRIPTION
Since SMODS.DrawStep was added and used, Cryptid edition/enhancement/sticker/etc decks in Galdur's new run menu do not show correctly. This PR attempts to band-aid fix that.

Also, the `Card:click` hook at enhanced.lua ([link](https://github.com/MathIsFun0/Cryptid/blob/66767a001d76774bc48b0ef6d7d9b80397c25d48/items/enhanced.lua#L350)) is still broken on the vanilla new run menu when Galdur is present and disabled internally through its own `Galdur.config.use` setting.