### PR TITLE
Globally define discard_cards_from_highlighted

### DIFF
--- a/lovely/code.toml
+++ b/lovely/code.toml
@@ -280,7 +280,16 @@ else
 		draw_card(G.cry_runarea,G.hand, i*100/#G.cry_runarea.cards,'up', true)
 	end
 end
-G.FUNCS.draw_from_hand_to_run = function(e)	-- might as well just slap this here
+'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "functions/state_events.lua"
+pattern = '''G.FUNCS.draw_from_deck_to_hand = function(e)'''
+position = "before"
+payload = '''
+G.FUNCS.draw_from_hand_to_run = function(e)
 	local hand_count = #G.hand.cards
 	for i=1, hand_count do --draw cards from deck
 		draw_card(G.hand, G.cry_runarea, i*100/hand_count,'down', nil, nil,  0.08)


### PR DESCRIPTION
Was previously defined in another `G.FUNCS` function for some reason, instead of globally.

This could apparently crash under very specific circumstances: https://discord.com/channels/1264429948970733782/1264430590527012924/1348097494890053733