### PR TITLE
Fixed the debug+ spam from scalae/double scale

### DIFF
--- a/items/epic.lua
+++ b/items/epic.lua
@@ -939,7 +939,6 @@ local double_scale = {
 	atlas = "atlasepic",
 	--todo: support jokers that scale multiple variables
 	cry_scale_mod = function(self, card, joker, orig_scale_scale, true_base, orig_scale_base, new_scale_base)
-		print(orig_scale_scale, true_base, orig_scale_base, new_scale_base)
 		if Cryptid.gameset(self) == "exp_modest" then
 			return true_base * 2
 		end


### PR DESCRIPTION
removed print statement that would send a message everytime scalae/double scale is triggered when debug+ is used (this annoyed me very much)
discord username: MrDingus