### PR TITLE
fix: crash on some weird systems

### DIFF
--- a/lib/https.lua
+++ b/lib/https.lua
@@ -1,9 +1,14 @@
 -- Update the Cryptid member count using HTTPS
 local member_fallback = 24000
-local https = require("SMODS.https")
+local succ, https = pcall(require, "SMODS.https")
 local last_update_time = 0
 local initial = true
 Cryptid.member_count = member_fallback
+if not succ then
+	sendErrorMessage("HTTP module could not be loaded. " .. tostring(https), "Cryptid")
+	return
+end
+
 local function apply_discord_member_count(code, body, headers)
 	if body then
 		Cryptid.member_count = string.match(body, '"approximate_member_count"%s*:%s*(%d+)')


### PR DESCRIPTION
This fixes a crash on some weird modded systems (*cough cough* mobile *cough cough*) that don't have a https backend. Untested cause I was too lazy to debug cryptid crashing on my machine.