### PR TITLE
Fix crash when multiple mods

### DIFF
--- a/items/exotic.lua
+++ b/items/exotic.lua
@@ -438,7 +438,8 @@ local redeo = {
 	init = function(self)
 		local ed = ease_dollars
 		function ease_dollars(mod, x)
-			ed(mod, x)
+			local mod_val = (type(mod) == "table" and tonumber(mod.array[1]) * (mod.sign or 1) or mod)
+			ed(mod_val, x)
 			for i = 1, #G.jokers.cards do
 				local effects = G.jokers.cards[i]:calculate_joker({ cry_ease_dollars = mod })
 			end


### PR DESCRIPTION
I also have my full list of mods as a repo, if I don't have these 3 changes for exotic it straight up crashes and says its because its comparing a table to a number, if I keep this it doesn't crash anymore.