### PR TITLE
Added check for if to_number returns a string within pluralize. 

### DIFF
--- a/lib/misc.lua
+++ b/lib/misc.lua
@@ -184,6 +184,7 @@ function Cryptid.pluralize(str, vars)
 			table.insert(_table, v)
 		end
 		local num = vars[tonumber(string.match(str, ">(%d+)"))] -- gets reference variable
+		if type(num) == 'string' then num = (Big and to_number(to_big(num))) or num end
 		local plural = _table[1] -- default
 		local checks = { [1] = "=" } -- checks 1 by default
 		local checks1mod = false -- tracks if 1 was modified


### PR DESCRIPTION
# Issue
Crustulum, and I assume other jokers too, would have it's value reach an omega-number ("e###e###"), then the game would crash. 

# Cause 
https://github.com/MathIsFun0/Cryptid/blob/4ebd1d4e5437cbe3708776a0c446cfc4bbd4812f/lib/misc.lua#L186
Attempts to return the number from the vars table. If those numbers are OmegaNums ("e###e###"), to_number will just return the string itself and not an actual number, then later on in the `pluralize` function would try to use this string as an actual number and the game would crash. 

# Fix
Added:
https://github.com/bobjoe400/Cryptid/blob/831f3ac996c1e106c6b19b76cec77d6d0da4837b/lib/misc.lua#L187
```lua
if type(num) == 'string' then num = (Big and to_number(to_big(num))) or num end
```

To check to see if `num` is a string and if so, attempt to do a big number conversion on it. 

Adding this one line allows Crustulum, and I assume other jokers too, to be able to go even further beyond when it comes to ridiculous scaling. 