### PR TITLE
Properly use SMODS.has_no_rank and SMODS.has_no_suit instead of explicit check for Stone Cards

### DIFF
--- a/items/blind.lua
+++ b/items/blind.lua
@@ -427,7 +427,7 @@ local hammer = {
 	recalc_debuff = function(self, card, from_blind)
 		if card.area ~= G.jokers and not G.GAME.blind.disabled then
 			if
-				card.ability.effect ~= "Stone Card"
+				not SMODS.has_no_rank(card)
 				and (
 					card.base.value == "3"
 					or card.base.value == "5"
@@ -462,7 +462,7 @@ local magic = {
 	recalc_debuff = function(self, card, from_blind)
 		if card.area ~= G.jokers and not G.GAME.blind.disabled then
 			if
-				card.ability.effect ~= "Stone Card"
+				not SMODS.has_no_rank(card)
 				and (
 					card.base.value == "2"
 					or card.base.value == "4"

--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -191,7 +191,7 @@ function reset_castle_card()
 	G.GAME.current_round.cry_dropshot_card.suit = "Spades"
 	local valid_castle_cards = {}
 	for k, v in ipairs(G.playing_cards) do
-		if v.ability.effect ~= "Stone Card" then
+		if not SMODS.has_no_suit(v) then
 			valid_castle_cards[#valid_castle_cards + 1] = v
 		end
 	end


### PR DESCRIPTION
Rank blinds and Dropshot weren't up to date