### PR TITLE
Fixed Pot of Jokes internally storing values over it's set limit

### DIFF
--- a/items/misc_joker.lua
+++ b/items/misc_joker.lua
@@ -239,12 +239,15 @@ local potofjokes = {
 	end,
 	calculate = function(self, card, context)
 		if context.end_of_round and not context.individual and not context.repetition and not context.blueprint then
-			G.hand:change_size(math.min(math.max(0, 1000 - card.ability.extra.h_size), card.ability.extra.h_mod))
-			card.ability.extra.h_size = card.ability.extra.h_size + card.ability.extra.h_mod
-			if to_big(card.ability.extra.h_size) > 1000 then 
+			if to_big(card.ability.extra.h_size) + to_big(card.ability.extra.h_mod) >= to_big(1000) then 
 				card.ability.extra.h_size = 1000 
-				card.abiliyt.extra.h_mod = 0
+				card.ability.extra.h_mod = 0
 			end
+
+			G.hand:change_size(math.min(math.max(0, 1000 - card.ability.extra.h_size), card.ability.extra.h_mod))
+			
+			card.ability.extra.h_size = card.ability.extra.h_size + card.ability.extra.h_mod
+
 			return {
 				message = localize({ type = "variable", key = "a_handsize", vars = { card.ability.extra.h_mod } }),
 				colour = G.C.FILTER,

--- a/items/misc_joker.lua
+++ b/items/misc_joker.lua
@@ -241,6 +241,10 @@ local potofjokes = {
 		if context.end_of_round and not context.individual and not context.repetition and not context.blueprint then
 			G.hand:change_size(math.min(math.max(0, 1000 - card.ability.extra.h_size), card.ability.extra.h_mod))
 			card.ability.extra.h_size = card.ability.extra.h_size + card.ability.extra.h_mod
+			if to_big(card.ability.extra.h_size) > 1000 then 
+				card.ability.extra.h_size = 1000 
+				card.abiliyt.extra.h_mod = 0
+			end
 			return {
 				message = localize({ type = "variable", key = "a_handsize", vars = { card.ability.extra.h_mod } }),
 				colour = G.C.FILTER,


### PR DESCRIPTION
# Issue
Pot of jokes would continue to store values internally, even though it's displayed as 1000, over 1000 for `extra.h_size` and then crashing the game by passing these into `CardArea:change_size`

# Fix
Hard clamp the values of `extra.h_size` and `extra.h_mod` to 1000 and 0 when `extra.h_size + extra.h_mod` gets to be equal to or greater than 1000. 

# Requirements
None

# Files Changed
`misc.lua`
* Added hardcoded clamping to Pot of Jokes internal values