### PR TITLE
Ability to skip over whole tables in misprintize

### DIFF
--- a/lib/misprintize.lua
+++ b/lib/misprintize.lua
@@ -41,7 +41,7 @@ function Cryptid.misprintize_tbl(name, ref_tbl, ref_value, clear, override, stac
 				end
 			elseif
 				not (k == "immutable") 
-				then
+			then
 
 				for _k, _v in pairs(tbl[k]) do
 					if

--- a/lib/misprintize.lua
+++ b/lib/misprintize.lua
@@ -39,7 +39,10 @@ function Cryptid.misprintize_tbl(name, ref_tbl, ref_value, clear, override, stac
 						big
 					)
 				end
-			else
+			elseif
+				not (k == "immutable") 
+				then
+
 				for _k, _v in pairs(tbl[k]) do
 					if
 						is_number(tbl[k][_k])


### PR DESCRIPTION
# New Idea
Add "immutable" tables to a card's ability. Allow `misprintize_tbl` to skip over these tables so certain values of a joker aren't modified, resulting in a more granular approach to immutability. 

# Result
Added a few lines to `misprintize_tbl` to check if our table name is "immutable", if so, skip that table. 

# Requirements
None

# Files changed
`lib/misprintize.lua`
* Added check for table name of "immutable" within `misprintize_tbl`

# Testing
This has been tested with the new Pot of Jokes implementation:
 * #508