### PR TITLE
Update Midas Mask/Vampire forcetrigger code, fix Midas Mask crash

### DIFF
--- a/lib/forcetrigger.lua
+++ b/lib/forcetrigger.lua
@@ -465,8 +465,6 @@ function Cryptid.forcetrigger(card, context)
 			}))
 		end
 		if card.ability.name == "Vampire" then
-			local check = nil
-			local enhanced = {}
 			if context.scoring_hand and #context.scoring_hand > 0 then
 				for k, v in ipairs(context.scoring_hand) do
 					if v.config.center ~= G.P_CENTERS.c_base and not v.debuff and not v.vampired then
@@ -476,9 +474,7 @@ function Cryptid.forcetrigger(card, context)
 					end
 					v.vampired = nil
 				end
-				check = true
-			end
-			if not check and G and G.hand and #G.hand.highlighted > 0 then
+			elseif G and G.hand and #G.hand.highlighted > 0 then
 				for k, v in ipairs(G.hand.highlighted) do
 					if v.config.center ~= G.P_CENTERS.c_base and not v.debuff and not v.vampired then
 						enhanced[#enhanced + 1] = v
@@ -487,7 +483,6 @@ function Cryptid.forcetrigger(card, context)
 					end
 					v.vampired = nil
 				end
-				check = true
 			end
 			card.ability.x_mult = card.ability.x_mult + (card.ability.extra * #enhanced or 1)
 			results = { jokers = { Xmult_mod = card.ability.x_mult, card = card } }
@@ -531,7 +526,6 @@ function Cryptid.forcetrigger(card, context)
 		end
 		-- page 6
 		if card.ability.name == "Midas Mask" then
-			local check = nil
 			if context.scoring_hand then
 				for k, v in ipairs(context.scoring_hand) do
 					if v:is_face() then
@@ -546,10 +540,8 @@ function Cryptid.forcetrigger(card, context)
 						}))
 					end
 				end
-				check = true
-			end
-			if not check and G and G.hand and #G.hand.highlighted > 0 then
-				for k, v in ipairs(context.scoring_hand) do
+			elseif G and G.hand and #G.hand.highlighted > 0 then
+				for k, v in ipairs(G.hand.highlighted) do
 					if v:is_face() then
 						v:set_ability(G.P_CENTERS.m_gold, nil, true)
 						G.E_MANAGER:add_event(Event({
@@ -562,7 +554,6 @@ function Cryptid.forcetrigger(card, context)
 						}))
 					end
 				end
-				check = true
 			end
 		end
 		if card.ability.name == "Luchador" then


### PR DESCRIPTION
- Fixed Midas Mask crashing when force triggered without a scoring hand
- Updated both Midas Mask and Vampire's force trigger code to use `elseif` instead of a weird `check` boolean

As a note, it might be better just to completely axe the behaviors of Vampire and Midas Mask acting on highlighted cards if a hand hasn't been played, since both specify their effects only happening on played cards. Activating on highlighted cards could potentially be confusing. I'm just fixing bugs here though.