### PR TITLE
fix: improved stability

### DIFF
--- a/lib/ascended.lua
+++ b/lib/ascended.lua
@@ -137,7 +137,7 @@ function G.FUNCS.get_poker_hand_info(_cards)
 			a_power = 0
 		end
 	end
-	if a_power > 0 then
+	if to_number(a_power) > 0 then
 		G.GAME.current_round.current_hand.cry_asc_num = a_power
 		-- Change mult and chips colors if hand is ascended
 		if not hidden then

--- a/lib/misprintize.lua
+++ b/lib/misprintize.lua
@@ -482,7 +482,9 @@ function Cryptid.manipulate(card, args)
 				end
 			end
 			--ew ew ew ew
-			G.P_CENTERS[card.config.center.key].config = config
+			if G.P_CENTERS[card.config.center.key] then
+				G.P_CENTERS[card.config.center.key].config = config
+			end
 		end
 		return true
 	end

--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -915,7 +915,7 @@ function create_card(_type, area, legendary, _rarity, skip_materialize, soulable
 	end
 
 	if forced_key and not G.GAME.banned_keys[forced_key] then
-		_type = (G.P_CENTERS[forced_key].set ~= "Default" and G.P_CENTERS[forced_key].set or _type)
+		_type = (G.P_CENTERS[forced_key] and G.P_CENTERS[forced_key].set ~= "Default" and G.P_CENTERS[forced_key].set or _type)
 	end
 
 	local front = (SMODS.set_create_card_front and (_type == "Base" or _type == "Enhanced")) or nil


### PR DESCRIPTION
I made changes based on this log: 

---------------------------------------------------------------------------------------------
`Oops! The game crashed:`
`[SMODS Cryptid "lib/misprintize.lua"]:485: attempt to index a nil value`


```
Development version of Steamodded detected! If you are not actively developing a mod, please try using the latest release instead.



Additional Context:
Balatro Version: 1.0.1o-FULL
Modded Version: 1.0.0~BETA-1216a-STEAMODDED
LÖVE Version: 11.5.0
Lovely Version: 0.8.0
Platform: Android
Steamodded Mods:
    1: Better Vouchers This Run UI by Betmma [ID: BetterVouchersThisRunUI]
    2: Cartomancer by stupxd aka stupid [ID: cartomancer, Priority: 69, Version: 4.16-smods-fix, Uses Lovely]
    3: re:Unlock All by wingedcatgirl [ID: reUnlock, Version: 1.1.2, Uses Lovely]
    4: Paperback by PaperMoon, OppositeWolf770, srockw, Nether, B [ID: paperback, Version: 0.7.1a~BETA, Uses Lovely]
    5: Nopeus by jenwalter666, stupxd, snowylight [ID: nopeus, Priority: -33, Version: 1.0.1, Uses Lovely]
    6: Banner by SylviBlossom [ID: banner, Version: 1.1.1, Uses Lovely]
    7: Cryptid by MathIsFun_, Cryptid and Balatro Discords [ID: Cryptid, Priority: 114, Version: 0.5.13, Uses Lovely]
    8: fpscap by snowylight [ID: fpscap]
    9: Blueprint by stupxd aka stupid, Jonathan [ID: blueprint, Priority: 69, Version: 3.3, Uses Lovely]
    10: Ortalab by Ortalab Team [ID: ortalab, Version: 1.0.1a, Uses Lovely]
    11: Speedmaster by snowylight [ID: Speedmaster, Priority: 100, Version: 1.1.3]
    12: UltraHand by Xioxin, snowylight [ID: ultrahand, Version: 1.1.0]
    13: Talisman by MathIsFun_, Mathguy24, jenwalter666, cg-223, lord.ruby [ID: Talisman, Version: 2.6, Uses Lovely]
    14: Sculio by crmykybord, BrandonE, chily [ID: Sculio, Version: 1.0.0]
    15: Entropy by Ruby, The Entropy Discord [ID: entr, Priority: 666, Version: 1.1.0, Uses Lovely]
    16: TEOcean Language Packs by mleaf233 [ID: teocean, Priority: -10, Version: 1.0.6]
    17: Escape Exit Button by Steamo [ID: EscapeExitButton, Priority: 1000]
    18: Card Sleeves by Larswijn [ID: CardSleeves, Priority: -10, Version: 1.8.1, Uses Lovely]
    19: Better Tags by WaffleDevs [ID: bettertags, Version: 1.0.0, Uses Lovely]
    20: Cryptlib by The Cryptid discord [ID: Cryptlib, Version: 1.1.4, Uses Lovely]
    21: Galdur by Eremel_ [ID: galdur, Priority: -10000, Version: 1.2.1d, Uses Lovely]
Lovely Mods:
    1: Bm原版修正补丁1.02l

Stack Traceback
===============
(3) Lua field 'manipulate' at file 'lib/misprintize.lua:485' (from mod with id Cryptid)
Local variables:
 card = table: 0x71b0bd18c0  {ID:96016, ignore_shadow:table: 0x71b0bd9380, role:table: 0x71b0bd29e0, RETS:table: 0x71b0bd1a78, CT:table: 0x71b0bd24b8, click_offset:table: 0x71b0bd1d48 (more...)}
 args = table: 0x72475c56d0  {no_deck_effects:true, min:1, max:1, type:X, dont_stack:true}
 func = Lua function '?' (defined at line 415 of chunk [SMODS Cryptid "lib/misprintize.lua"])
 config = table: 0x72475c5850  {type:voucher_add}
 (*temporary) = nil
 (*temporary) = string: "tag_voucher"
 (*temporary) = table: 0x71b0bd18c0  {ID:96016, ignore_shadow:table: 0x71b0bd9380, role:table: 0x71b0bd29e0, RETS:table: 0x71b0bd1a78, CT:table: 0x71b0bd24b8, click_offset:table: 0x71b0bd1d48 (more...)}
 (*temporary) = table: 0x72475c59e0  {}
 (*temporary) = C function: next
 (*temporary) = table: 0x72475c59e0  {}
 (*temporary) = userdata: NULL
 (*temporary) = table: 0x71b0bd18c0  {ID:96016, ignore_shadow:table: 0x71b0bd9380, role:table: 0x71b0bd29e0, RETS:table: 0x71b0bd1a78, CT:table: 0x71b0bd24b8, click_offset:table: 0x71b0bd1d48 (more...)}
 (*temporary) = string: "base"
 (*temporary) = table: 0x72475c56d0  {no_deck_effects:true, min:1, max:1, type:X, dont_stack:true}
 (*temporary) = nil
 (*temporary) = C function: next
 (*temporary) = table: 0x71b0bd9620  {times_played:0, nominal:0, face_nominal:0, suit_nominal_original:0, suit_nominal:0}
 (*temporary) = string: "attempt to index a nil value"
(4) Lua upvalue 'ref' at file 'lib/overrides.lua:1128' (from mod with id Cryptid)
Local variables:
 _type = string: "Tag"
 area = table: 0x72da237da0  {cards:table: 0x72d9122fe0, ID:784, role:table: 0x72d93e7c00, RETS:table: 0x72da2c12c8, CT:table: 0x72d9481d58, click_offset:table: 0x72d9481cf0 (more...)}
 legendary = nil
 _rarity = nil
 skip_materialize = boolean: true
 soulable = nil
 forced_key = string: "tag_voucher"
 key_append = nil
 area = table: 0x72da237da0  {cards:table: 0x72d9122fe0, ID:784, role:table: 0x72d93e7c00, RETS:table: 0x72da2c12c8, CT:table: 0x72d9481d58, click_offset:table: 0x72d9481cf0 (more...)}
 pseudo = Lua function '?' (defined at line 881 of chunk [SMODS Cryptid "lib/overrides.lua"])
 ps = Lua function '?' (defined at line 333 of chunk functions/misc_functions.lua)
 aeqviable = Lua function '?' (defined at line 894 of chunk [SMODS Cryptid "lib/overrides.lua"])
 front = nil
 card = table: 0x71b0bd18c0  {ID:96016, ignore_shadow:table: 0x71b0bd9380, role:table: 0x71b0bd29e0, RETS:table: 0x71b0bd1a78, CT:table: 0x71b0bd24b8, click_offset:table: 0x71b0bd1d48 (more...)}
 center = table: 0x72da53d970  {discovered:true, unlocked:true, pixel_size:table: 0x71b0bd1790, order:8, _saved_d_u:true, pos:table: 0x72da53db00, alerted:true, key:tag_voucher (more...)}
(5) Lua global 'create_card' at file 'lib/hooks.lua:2024' (from mod with id entr)
Local variables:
 _type = string: "Tag"
 area = table: 0x72da237da0  {cards:table: 0x72d9122fe0, ID:784, role:table: 0x72d93e7c00, RETS:table: 0x72da2c12c8, CT:table: 0x72d9481d58, click_offset:table: 0x72d9481cf0 (more...)}
 legendary = nil
 _rarity = nil
 skip_materialize = boolean: true
 soulable = nil
 forced_key = string: "tag_voucher"
 key_append = nil
 dont_calculate = nil
(6) Lua field 'create_card' at Steamodded file 'src/utils.lua:385' 
Local variables:
 t = table: 0x71b0bd15f0  {key:tag_voucher, area:table: 0x72da237da0, skip_materialize:true, set:Tag}
(7) Lua field 'add_card' at Steamodded file 'src/utils.lua:407' 
Local variables:
 t = table: 0x71b0bd15f0  {key:tag_voucher, area:table: 0x72da237da0, skip_materialize:true, set:Tag}
(8) Lua field 'func' at file 'objects/patches.lua:811' (from mod with id ortalab)
Local variables:
 tag = string: "tag_voucher"
 index = number: 8
 (*temporary) = table: 0x71aab251e0  {}
 (*temporary) = number: 1
(9) Lua method 'handle' at file 'engine/event.lua:55'
Local variables:
 self = table: 0x71aab25408  {delay:1.8, created_on_pause:false, trigger:after, blocking:true, timer:TOTAL, func:function: 0x71aab252d8, time:113.04427158899, blockable:true (more...)}
 _results = table: 0x7251213548  {completed:false, pause_skip:false, time_done:true, blocking:true}
(10) Lua method 'update' at file 'engine/event.lua:182'
Local variables:
 self = table: 0x72da5c0088  {queues:table: 0x72da598610, queue_dt:0.016666666666667, queue_last_processed:18.4, queue_timer:25.260198814367}
 dt = number: 0.0301922
 forced = nil
 (for generator) = C function: next
 (for state) = table: 0x72da598610  {galdur:table: 0x72ce8b6460, other:table: 0x72da5654e0, base:table: 0x72da5e0d40, unlock:table: 0x72da5432b0, tutorial:table: 0x72da542138, achievement:table: 0x72ce565dd0 (more...)}
 (for control) = userdata: NULL
 k = string: "base"
 v = table: 0x72da5e0d40  {1:table: 0x71db79fee8, 2:table: 0x71aab25408, 3:table: 0x71c7e2f9d8, 4:table: 0x71b2062f80, 5:table: 0x71d4c32c48, 6:table: 0x71aab25548, 7:table: 0x71c95debc0 (more...)}
 blocked = boolean: false
 i = number: 2
 results = table: 0x7251213548  {completed:false, pause_skip:false, time_done:true, blocking:true}
(11) Lua upvalue 'gameUpdateRef' at file 'game.lua:2801'
Local variables:
 self = table: 0x72cea80b68  {F_HIDE_BG:false, P_LOCKED:table: 0x71db5f8578, ANIMATION_ATLAS:table: 0x72ce9b5f30, VIBRATION:0, entr_hooked:true, play:table: 0x72da237da0, ANIMATION_FPS:10 (more...)}
 dt = number: 0.0301922
 http_resp = nil
(12) Lua upvalue 'upd' at Steamodded file 'src/ui.lua:126' 
Local variables:
 self = table: 0x72cea80b68  {F_HIDE_BG:false, P_LOCKED:table: 0x71db5f8578, ANIMATION_ATLAS:table: 0x72ce9b5f30, VIBRATION:0, entr_hooked:true, play:table: 0x72da237da0, ANIMATION_FPS:10 (more...)}
 dt = number: 0.0301922
(13) Lua upvalue 'gu' at file 'main.lua:2150'
Local variables:
 self = table: 0x72cea80b68  {F_HIDE_BG:false, P_LOCKED:table: 0x71db5f8578, ANIMATION_ATLAS:table: 0x72ce9b5f30, VIBRATION:0, entr_hooked:true, play:table: 0x72da237da0, ANIMATION_FPS:10 (more...)}
 dt = number: 0.0301922
(14) Lua upvalue 'upd' at file 'lib/gameset.lua:27' (from mod with id Cryptid)
Local variables:
 self = table: 0x72cea80b68  {F_HIDE_BG:false, P_LOCKED:table: 0x71db5f8578, ANIMATION_ATLAS:table: 0x72ce9b5f30, VIBRATION:0, entr_hooked:true, play:table: 0x72da237da0, ANIMATION_FPS:10 (more...)}
 dt = number: 0.0301922
(15) Lua upvalue 'update_ref' at file 'lib/overrides.lua:370' (from mod with id Cryptid)
Local variables:
 self = table: 0x72cea80b68  {F_HIDE_BG:false, P_LOCKED:table: 0x71db5f8578, ANIMATION_ATLAS:table: 0x72ce9b5f30, VIBRATION:0, entr_hooked:true, play:table: 0x72da237da0, ANIMATION_FPS:10 (more...)}
 dt = number: 0.0301922
(16) Lua upvalue 'update_ref' at file 'lib/hooks.lua:1717' (from mod with id entr)
Local variables:
 self = table: 0x72cea80b68  {F_HIDE_BG:false, P_LOCKED:table: 0x71db5f8578, ANIMATION_ATLAS:table: 0x72ce9b5f30, VIBRATION:0, entr_hooked:true, play:table: 0x72da237da0, ANIMATION_FPS:10 (more...)}
 dt = number: 0.0301922
(17) Lua upvalue 'upd' at file 'lib/hooks.lua:2838' (from mod with id entr)
Local variables:
 self = table: 0x72cea80b68  {F_HIDE_BG:false, P_LOCKED:table: 0x71db5f8578, ANIMATION_ATLAS:table: 0x72ce9b5f30, VIBRATION:0, entr_hooked:true, play:table: 0x72da237da0, ANIMATION_FPS:10 (more...)}
 dt = number: 0.0301922
(18) Lua method 'update' at file 'lib/hooks.lua:3042' (from mod with id entr)
Local variables:
 self = table: 0x72cea80b68  {F_HIDE_BG:false, P_LOCKED:table: 0x71db5f8578, ANIMATION_ATLAS:table: 0x72ce9b5f30, VIBRATION:0, entr_hooked:true, play:table: 0x72da237da0, ANIMATION_FPS:10 (more...)}
 dt = number: 0.0301922
(19) Lua upvalue 'oldupd' at file 'main.lua:1218'
Local variables:
 dt = number: 0.0301922
(20) Lua field 'update' at file 'main.lua:2183'
Local variables:
 dt = number: 0.0301922
(21) Lua function '?' at file 'main.lua:946' (best guess)
(22) global C function 'xpcall'
(23) LÖVE function at file 'boot.lua:400' (best guess)
Local variables:
 func = Lua function '?' (defined at line 917 of chunk main.lua)
 inerror = boolean: true
 deferErrhand = Lua function '(LÖVE Function)' (defined at line 371 of chunk [love "boot.lua"])
 earlyinit = Lua function '(LÖVE Function)' (defined at line 378 of chunk [love "boot.lua"])
```

