### PR TITLE
Added legacy option in the config for using the old version of the "Rigged" sticker

### DIFF
--- a/Cryptid.lua
+++ b/Cryptid.lua
@@ -317,6 +317,12 @@ local cryptidConfigTab = function()
 		ref_table = Cryptid_config,
 		ref_value = "menu",
 	})
+	cry_nodes[#cry_nodes + 1] = create_toggle({
+		label = localize("cry_feat_alt_rigged"),
+		active_colour = HEX("1c5c23"),
+		ref_table = Cryptid_config,
+		ref_value = "alt_rigged",
+	})
 	cry_nodes[#cry_nodes + 1] = UIBox_button({
 		colour = G.C.CRY_ALTGREENGRADIENT,
 		button = "reset_gameset_config",

--- a/config.lua
+++ b/config.lua
@@ -11,4 +11,5 @@ return {
 	["force_tooltips"] = true, -- i don't actually know what this does
 	["HTTPS"] = true, -- your internet connection
 	["menu"] = true, -- i don't know what this does either
+	["alt_rigged"] = true, --reverts rigged to its old iteration
 }

--- a/items/code.lua
+++ b/items/code.lua
@@ -1,3 +1,7 @@
+local Config = SMODS.current_mod.config
+
+
+
 local code = {
 	object_type = "ConsumableType",
 	key = "Code",
@@ -1954,7 +1958,11 @@ local seed = {
 		return #cards == 1
 	end,
 	loc_vars = function(self, info_queue, card)
-		info_queue[#info_queue + 1] = { key = "cry_rigged", set = "Other", vars = {} }
+		if (Config.alt_rigged) then 
+			info_queue[#info_queue + 1] = { key = "cry_rigged_alt", set = "Other", vars = {} }
+		else
+			info_queue[#info_queue + 1] = { key = "cry_rigged", set = "Other", vars = {} }
+		end
 	end,
 	use = function(self, card, area, copier)
 		local cards = Cryptid.get_highlighted_cards({ G.jokers, G.hand, G.consumeables, G.pack_cards }, card, 1, 1)
@@ -1994,10 +2002,18 @@ local rigged = {
 	atlas = "sticker",
 	pos = { x = 6, y = 1 },
 	key = "cry_rigged",
+	loc_key = function(self)
+		return Config.alt_rigged and "cry_rigged_alt" or "cry_rigged"
+	end,
 	no_sticker_sheet = true,
 	prefix_config = { key = false },
 	badge_colour = HEX("14b341"),
 	order = 605,
+	loc_vars = function(self, info_queue, card)
+		return {
+			key = Config.alt_rigged and "cry_rigged_alt" or "cry_rigged"
+		}
+	end,
 	draw = function(self, card) --don't draw shine
 		local notilt = nil
 		if card.area and card.area.config.type == "deck" then
@@ -2026,9 +2042,15 @@ local rigged = {
 	end,
 	calculate = function(self, card, context)
 		if context.mod_probability and context.trigger_obj == card then
-			return {
-				numerator = context.numerator * 2,
-			}
+			if (Config.alt_rigged) then
+				return{
+					numerator = context.denominator
+				}
+			else
+				return {
+					numerator = context.numerator * 2,
+				}
+			end
 		end
 	end,
 }

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -4501,6 +4501,13 @@ return {
 					"on this card",
 				},
 			},
+			cry_rigged_alt = {
+				name = "Rigged",
+				text = {
+					"All {C:cry_code}listed{} probabilities",
+					"are {C:cry_code}guaranteed",
+				},
+			},
 			cry_hooked = {
 				name = "Hooked",
 				text = {
@@ -5142,6 +5149,7 @@ return {
 			["cry_feat_exotic jokers"] = "Exotic Jokers",
 			["cry_feat_m jokers"] = "M Jokers",
 			cry_feat_menu = "Custom Main Menu",
+			cry_feat_alt_rigged = "Legacy Rigging",
 			["cry_feat_misc."] = "Misc.",
 			["cry_feat_misc. jokers"] = "Misc. Jokers",
 			cry_feat_planets = "Planets",


### PR DESCRIPTION
Hi fellas. Inspector_B here.

After reviewing the changes to Rigged (doubling the probability instead of guaranteeing it), I became furious there was no option to revert it like it used to. I said to myself:

"That's it. I am angry. I was trying to be an nice guy. I tried to humble you but now I am angry. I tried to warn you. I tried to be nice. The devil is shivering right now and crying on the floor. The volcanoes are erupting as I am typing this. You have made me angry. Me and my 4 wives are all angry. I am no longer laughing nor joking. You made me really angry. I will now not warn you. I will now Jolly you. This is it. This is the end. The sky is turning red from what I am about to do. With my 240 IQ. And 1% Of my braincell you are now about to be punished by me. Say your final goodbyes. "

And then I morbed all over the ground or something.

I then spent like 2.5 hours making a legacy option and rigged it up (get it) so that if players want to use the old version, they can. (It still requires rebooting the game after changing the option, like most of the other config options)