### PR TITLE
fix: prevent nil-indexing crash in LeBaron James enhancement calculation

### DIFF
--- a/items/misc_joker.lua
+++ b/items/misc_joker.lua
@@ -10080,7 +10080,7 @@ local lebaron_james = {
 			if
 				not ret
 				and next(SMODS.find_card("j_cry_lebaron_james"))
-				and SMODS.Ranks[self.base.value].key == "King"
+				and (SMODS.Ranks[self.base.value] or {}).key == "King"
 				and context.cardarea == G.play
 			then
 				context.cardarea = G.hand


### PR DESCRIPTION
This PR adds a nil check for the card rank in the LeBaron James enhancement calculation logic to prevent crashes when modded cards with non-standard ranks are evaluated.