### PR TITLE
Fix crash when force-triggering Castle, Runner, or Ice Cream

### DIFF
--- a/lib/forcetrigger.lua
+++ b/lib/forcetrigger.lua
@@ -300,7 +300,7 @@ function Cryptid.forcetrigger(card, context)
 		end
 		if card.ability.name == "Runner" then
 			SMODS.scale_card(card, {
-				ref_table = card.ability,
+				ref_table = card.ability.extra,
 				ref_value = "chips",
 				scalar_value = "chip_mod",
 				no_message = true,
@@ -309,7 +309,7 @@ function Cryptid.forcetrigger(card, context)
 		end
 		if card.ability.name == "Ice Cream" then
 			SMODS.scale_card(card, {
-				ref_table = card.ability,
+				ref_table = card.ability.extra,
 				ref_value = "chips",
 				scalar_value = "chip_mod",
 				operation = "-",
@@ -776,7 +776,7 @@ function Cryptid.forcetrigger(card, context)
 		-- if card.ability.name == "Seltzer" then results = { jokers = { } } end
 		if card.ability.name == "Castle" then
 			SMODS.scale_card(card, {
-				ref_table = card.ability,
+				ref_table = card.ability.extra,
 				ref_value = "chips",
 				scalar_value = "chip_mod",
 				no_message = true,


### PR DESCRIPTION
Force-triggering Castle, Runner, or Ice Cream crashes the game with an arithmetic-on-nil exception. Comparing the force trigger code of these jokers with that of Wee Joker (which doesn't crash), Wee Joker invokes SMODS.scale_card with "ref_table = card.ability.extra" while the crashing jokers invoke the same function with "ref_table = card.ability". Changing the crashing jokers to refer to card.ability.extra instead of card.ability prevents the crash and makes them work the same as Wee Joker when force-triggered.