### PR TITLE
Fix crash when force triggering Class

### DIFF
--- a/items/code.lua
+++ b/items/code.lua
@@ -3317,17 +3317,17 @@ local class = {
 	force_use = function(self, card, area)
 		G.CODE_MAX_HIGHLIGHT = card.ability.max_highlighted
 		local choices = {
-			"bonus",
-			"mult",
-			"wild",
-			"glass",
-			"steel",
-			"stone",
-			"gold",
-			"lucky",
-			"echo",
-			"light",
-			"abstract",
+			"m_bonus",
+			"m_mult",
+			"m_wild",
+			"m_glass",
+			"m_steel",
+			"m_stone",
+			"m_gold",
+			"m_lucky",
+			"m_cry_echo",
+			"m_cry_light",
+			"m_cry_abstract",
 		}
 		for i, v in pairs(Cryptid.get_highlighted_cards({ G.hand }, {}, 1, card.ability.max_highlighted or 1)) do
 			v:set_ability(pseudorandom_element(choices, pseudoseed("forceclass")))


### PR DESCRIPTION
When the code card Class is force-triggered, it's supposed to choose a random card in hand to apply a random enhancement to. To do this, Class's force_use function picks randomly from a table listing off all enhancements from vanilla and Cryptid. However, the strings in the table do not match the enhancements' actual identifiers, which causes the game to attempt to apply an undefined enhancement, which leads to a failed assertion at gameset.lua:606, which crashes the game.

This change replaces the strings in the table with the correct versions, fixing the crash and allowing Class to work as intended when force-triggered.