### PR TITLE
Fix crash when playing a declare hand against Nostalgic Serpent

### DIFF
--- a/items/blind.lua
+++ b/items/blind.lua
@@ -153,7 +153,7 @@ local oldserpent = {
 	order = 9,
 	boss_colour = HEX("4f6367"),
 	modify_hand = function(self, cards, poker_hands, text, mult, hand_chips)
-		if G.GAME.hands[text].level > to_big(1) then
+		if to_big(G.GAME.hands[text].level) > to_big(1) then
 			G.GAME.blind.triggered = true
 			return math.floor(mult / G.GAME.hands[text].level), hand_chips, true
 		end


### PR DESCRIPTION
Playing a Declare hand against Nostalgic Serpent crashes the game. Checking the crash log, the game dies with an "attempt to compare table with number" exception when it tries to check if the Declare hand has been leveled up at least once.

From what I can discern from looking at the code, the game seems to be assuming that G.GAME.hands[text].level is already in the table representation used for big numbers, but in the case of Declare hands this assumption does not hold.

Feeding the played hand's level through to_big before making the comparison fixes the crash. Grepping through the files for other instances of G.GAME.hands[...].level, I can confirm this is consistent with how comparisons between hand level and a constant are implemented elsewhere in this mod.