### PR TITLE
Fix alt tab none crash, issues with Kitty Printer interaction

### DIFF
--- a/items/code.lua
+++ b/items/code.lua
@@ -4335,17 +4335,16 @@ local alttab = {
 	loc_vars = function(self, info_queue, card)
 		local ret = localize("k_none")
 		if Cryptid.safe_get(G.GAME, "blind", "in_blind") then
-			if G.GAME.blind:get_type() == "Small" then
+			local tag = Cryptid.get_next_tag()
+			if tag then
+				ret = localize({ type = "name_text", key = tag, set = "Tag" })
+			elseif G.GAME.blind:get_type() == "Small" then
 				ret = localize({ type = "name_text", key = G.GAME.round_resets.blind_tags.Small, set = "Tag" })
 			elseif G.GAME.blind:get_type() == "Big" then
 				ret = localize({ type = "name_text", key = G.GAME.round_resets.blind_tags.Big, set = "Tag" })
 			elseif G.GAME.blind:get_type() == "Boss" then
 				ret = "???"
 			end
-		end
-		local tag = Cryptid.get_next_tag()
-		if tag then
-			ret = localize({ type = "name_text", key = tag, set = "Tag" })
 		end
 		return { vars = { ret } }
 	end,

--- a/items/code.lua
+++ b/items/code.lua
@@ -4353,6 +4353,9 @@ local alttab = {
 		return Cryptid.safe_get(G.GAME, "blind", "in_blind")
 	end,
 	use = function(self, card, area, copier)
+		if not Cryptid.safe_get(G.GAME, "blind", "in_blind") then
+			return
+		end
 		local used_consumable = copier or card
 		delay(0.4)
 		G.E_MANAGER:add_event(Event({
@@ -4363,7 +4366,7 @@ local alttab = {
 				local tag = nil
 				local type = G.GAME.blind:get_type()
 				local tag_key = Cryptid.get_next_tag()
-				if tag_Key then
+				if tag_key then
 					tag = Tag(tag_key)
 				elseif type == "Boss" then
 					tag = Tag(get_next_tag_key())


### PR DESCRIPTION
This PR fixes three outstanding issues with the code card Alt-Tab.

1. When Alt-Tab is force triggered when it says "Current Tag: None" (i.e. in the shop or on the blind select screen), the game tries to generate an unrecognized tag and crashes. This is basically the same issue as the #838 crash, and the fix is the same: Check the condition in the use function itself just in case the "can use" condition was bypassed.
2. When the joker Kitty Printer exists, which replaces all skip tags with Cat Tags, Alt-Tab is supposed to respect that and produce only Cat Tags. This behavior was non-functional due to a capitalization typo when checking Cryptid.get_next_tag. This typo has been corrected, restoring the intended behavior.
3. Related to the above, Kitty Printer's presence is coded to modify Alt-Tab's description to display "Current Tag: Cat Tag" instead of the tag for the blind or "???". However, this modification erroneously took precedence over "Current Tag: None", even though Alt-Tab still cannot be used in the shop or the blind select screen. This precedence error has been corrected, such that Alt-Tab's description still says "Current Tag: None" in the shop and the blind select screen, whether or not Kitty Printer exists.