### PR TITLE
Fixed Double Down affecting jokers too many times

### DIFF
--- a/lovely/stake.toml
+++ b/lovely/stake.toml
@@ -43,7 +43,6 @@ while i <= #G.deck.cards do
 end
 if G.GAME.used_vouchers.v_cry_double_down then
     local function update_dbl(area)
-        local area = G.jokers
         for i = 1, #area.cards do
             if area.cards[i].ability.immutable and type(area.cards[i].ability.immutable.other_side) == "table" then
                 --tweak to do deck effects with on the flip side


### PR DESCRIPTION
The voucher Double Down is intended to multiply the values on the backs of double-faced cards by 1.5x each round. To do this, it iterates across all cards in each of the five main card areas: the joker tray, the consumable area, the hand, the deck, and the discard. In the name of DRY this is implemented as a local function that takes an area and iterates across it, then that function gets called once for each area.

Except... the argument is not actually read from in the local function. Instead, a new local variable with the same name as the argument is immediately declared and assigned to the joker tray, overshadowing the function argument. So when this local function is called five times, once for each area, what actually happens is that the joker tray gets upgraded five times and the other areas don't get upgraded at all.

Removing the line declaring the local variable allows references to "area" to correctly read from the function argument, applying Double Down once on each area as intended.