### PR TITLE
Fixed TC&UAoETMBS

### DIFF
--- a/items/misc_joker.lua
+++ b/items/misc_joker.lua
@@ -6161,15 +6161,25 @@ local annihalation = {
 		if context.joker_main and (to_big(card.ability.extra.emult) > to_big(1)) then
 			if next(context.poker_hands["cry_WholeDeck"]) then
 				return {
+					message = localize({
+						type = "variable",
+						key = "a_powmult",
+						vars = { number_format(card.ability.extra.emult) },
+					}),
+					Emult_mod = lenient_bignum(card.ability.extra.emult),
 					colour = G.C.DARK_EDITION,
-					Emult = lenient_bignum(card.ability.extra.emult),
 				}
 			end
 		end
 		if context.forcetrigger then
 			return {
+				message = localize({
+					type = "variable",
+					key = "a_powmult",
+					vars = { number_format(card.ability.extra.emult) },
+				}),
+				Emult_mod = lenient_bignum(card.ability.extra.emult),
 				colour = G.C.DARK_EDITION,
-				Emult = lenient_bignum(card.ability.extra.emult),
 			}
 		end
 	end,


### PR DESCRIPTION
The Complete and Utter Annihilation of Everything That Makes Balatro Sacred is a Joker that is intended to give ^5.2 mult if the played hand contains a The Entire Deck.

This functionality does not work, because the joker returns as output an object with the field "Emult", when the correct field is "Emult_mod". Correcting this erroneous field name allows The Complete and Utter Annihilation of Everything That Makes Balatro Sacred to work as intended.