### PR TITLE
Fixed Declare hand "considered to contain" properties

### DIFF
--- a/lovely/code.toml
+++ b/lovely/code.toml
@@ -693,8 +693,8 @@ payload = '''
 				key = "cry_Declare"..tostring(v.index)
 				local tbl = {cards}
 				local skey = ({
-					[0] = "Flush",
-					[1] = "Straight",
+					[0] = "Straight",
+					[1] = "Flush",
 					[2] = "Full House"
 				})[v.index]
 				results[key] = tbl


### PR DESCRIPTION
The three hands you're allowed to create with the code card Declare are always considered to contain certain poker hands for the purpose of triggering jokers such as Runner. The first hand is supposed to count as containing a Straight, the second as containing a Flush, and the third as containing a Full House. However, in actuality, the first hand is considered to count as a Flush and the second as a Straight. (The third is correctly considered a Full House).

This PR corrects the "counts as" mistake and allows all Declare hands to act as the hand they claim to act as.