### PR TITLE
Fixed Sol's Observatory effect

### DIFF
--- a/lib/ascended.lua
+++ b/lib/ascended.lua
@@ -246,11 +246,11 @@ function Cryptid.calculate_ascension_power(hand_name, hand_cards, hand_scoring_c
 	-- Get Ascension Power From Sol/Perkele (Observatory effect)
 	if
 		G.GAME.used_vouchers.v_observatory
-		and (next(SMODS.find_card("cry-sunplanet")) or next(SMODS.find_card("cry-Perkele")))
+		and (next(find_joker("cry-sunplanet")) or next(find_joker("cry-Perkele")))
 	then
 		-- switch this to not use find_joker eventually please for the love of god
-		local super_entropic_local_variable_that_stores_the_amount_of_suns = #SMODS.find_card("cry-sunplanet")
-			+ #SMODS.find_card("cry-Perkele")
+		local super_entropic_local_variable_that_stores_the_amount_of_suns = #find_joker("cry-sunplanet")
+			+ #find_joker("cry-Perkele")
 
 		if super_entropic_local_variable_that_stores_the_amount_of_suns == 1 then
 			bonus = bonus + 1


### PR DESCRIPTION
Sol is a special Planet Card that increases the stats of ascended hands. It has a unique effect when paired with the Observatory voucher, such that Observatory adds ascension power to all hands proportional to the log of the number of held copies of Sol. Or, at least, it's supposed to. Sol + Observatory currently does nothing. This is curious, because the tooltip displays the correct bonus to ascension power.

Looking into the functionality of the Sol + Observatory tooltip and comparing it with the actual code, the tooltip uses find_joker to scan for copies of Sol, whereas the actual effect uses SMODS.find_card. Evidently, find_joker works and SMODS.find_card doesn't.

I notice a comment in the source code begging for someone to change the implementation to not use find_joker; I'm not sure what the reasoning there is, but considering this mod's at the end of its maintenance lifecycle, ugly-but-functional is probably preferable to principled-but-broken.