### PR TITLE
Fixed Copy/Paste giving extra multiuse

### DIFF
--- a/items/code.lua
+++ b/items/code.lua
@@ -5101,6 +5101,10 @@ local copypaste = {
 					G.E_MANAGER:add_event(Event({
 						func = function()
 							local cards = copy_card(context.consumeable)
+							if G.GAME.ACTIVE_CODE_CARD then
+								-- don't copy the temporary multiuse increase for code cards that summon a UI
+								cards.ability.cry_multiuse = (cards.ability.cry_multiuse or 2) - 1
+							end
 							cards:add_to_deck()
 							G.consumeables:emplace(cards)
 							return true


### PR DESCRIPTION
Three code cards (Class, Exploit, and Variable) summon a UI to give the player a choice on how to apply them. These code cards do not spend a Multiuse charge until after the player's choice is confirmed. To implement this, and to make sure the code card doesn't get consumed until confirmation even if it's on its last charge, the game temporarily grants +1 charge to the consumable in use, then deducts that charge again after confirmation.

However, the Copy/Paste joker, which creates a copy of a used code card, doesn't account for this mechanic, which causes it to function incorrectly for those consumables. Copy/Paste triggers after the consumable is given +1 charge but before that charge is taken away again. The end result is that when Copy/Paste creates Class, Exploit, or Variable, the created card has one more Multiuse than it's supposed to.

This PR adds a check to Copy/Paste to detect this situation and deduct one Multiuse from the created card to correct for this phenomenon.