### PR TITLE
Fixed double-sided hybrid crash + visual issue with blank face of double-sided playing cards

### DIFF
--- a/items/misc.lua
+++ b/items/misc.lua
@@ -2252,7 +2252,6 @@ local double_sided = {
 						card.ability.immutable = {}
 					end
 					card.ability.immutable.other_side = curr_abil
-					card.ability.immutable.other_side.base = base
 					card.ability.immutable.other_side.playing_card = curr_pc
 					card.ability.immutable.other_side.key = key
 					card.ability.immutable.other_side.seal = G.P_SEALS[seal] and seal or nil

--- a/items/misc.lua
+++ b/items/misc.lua
@@ -2435,6 +2435,7 @@ G.FUNCS.can_merge_ds = function(e)
 		and not other.merged
 		and card.area
 		and card.area.config.type ~= "shop"
+		and (not not card.playing_card) == (not not other.playing_card) --prevents merging playing cards with non-playing cards, which can cause various issues
 	then
 		e.config.colour = G.C.PURPLE
 		e.config.button = "merge_ds"

--- a/items/misc.lua
+++ b/items/misc.lua
@@ -2440,7 +2440,6 @@ G.FUNCS.can_merge_ds = function(e)
 		and not other.merged
 		and card.area
 		and card.area.config.type ~= "shop"
-		and (not not card.playing_card) == (not not other.playing_card) --prevents merging playing cards with non-playing cards, which can cause various issues
 	then
 		e.config.colour = G.C.PURPLE
 		e.config.button = "merge_ds"

--- a/items/misc.lua
+++ b/items/misc.lua
@@ -2163,10 +2163,12 @@ local double_sided = {
 					else
 						card:remove_from_deck(true)
 					end
+					local curr_pc = card.playing_card
 					local curr_abil = copy_table(card.ability)
 					local key = card.config.center.key
 					local base = copy_table(card.base)
 					local seal = card.seal
+					card.playing_card = card.ability.immutable.other_side.playing_card
 					if card.ability.immutable.other_side.base then
 						card.base = card.ability.immutable.other_side.base
 					else
@@ -2194,6 +2196,8 @@ local double_sided = {
 						card.ability.immutable = {}
 					end
 					card.ability.immutable.other_side = curr_abil
+					card.ability.immutable.other_side.base = base
+					card.ability.immutable.other_side.playing_card = curr_pc
 					card.ability.immutable.other_side.key = key
 					card.ability.immutable.other_side.seal = G.P_SEALS[seal] and seal or nil
 					if next(find_joker("cry-Flip Side")) then
@@ -2213,9 +2217,11 @@ local double_sided = {
 						card:remove_from_deck(true)
 					end
 					local curr_abil = copy_table(card.ability)
+					local curr_pc = card.playing_card
 					local key = card.config.center.key
 					local seal = card.seal
 					local base = copy_table(card.base)
+					card.playing_card = card.ability.immutable.other_side.playing_card
 					if card.ability.immutable.other_side.base then
 						card.base = card.ability.immutable.other_side.base
 					else
@@ -2246,6 +2252,8 @@ local double_sided = {
 						card.ability.immutable = {}
 					end
 					card.ability.immutable.other_side = curr_abil
+					card.ability.immutable.other_side.base = base
+					card.ability.immutable.other_side.playing_card = curr_pc
 					card.ability.immutable.other_side.key = key
 					card.ability.immutable.other_side.seal = G.P_SEALS[seal] and seal or nil
 					if next(find_joker("cry-Flip Side")) then
@@ -2458,6 +2466,7 @@ G.FUNCS.merge_ds = function(e)
 	card.ability.immutable.other_side = copy_table(other.ability)
 	card.ability.immutable.other_side.key = copy_table(other.config.center.key)
 	card.ability.immutable.other_side.seal = copy_table(other.seal)
+	card.ability.immutable.other_side.playing_card = other.playing_card
 	if other.base.nominal ~= 0 then
 		card.ability.immutable.other_side.base = copy_table(other.base)
 	end

--- a/items/misc.lua
+++ b/items/misc.lua
@@ -2182,11 +2182,6 @@ local double_sided = {
 					end
 					if card.base.nominal ~= 0 then
 						SMODS.change_base(card, card.base.suit, card.base.value)
-					else
-						if card.children.front then
-							card.children.front:remove()
-							card.children.front = nil
-						end
 					end
 					card.seal = G.P_SEALS[card.ability.immutable.other_side.seal]
 							and card.ability.immutable.other_side.seal
@@ -2235,11 +2230,6 @@ local double_sided = {
 					end
 					if card.base.nominal ~= 0 then
 						SMODS.change_base(card, card.base.suit, card.base.value)
-					else
-						if card.children.front then
-							card.children.front:remove()
-							card.children.front = nil
-						end
 					end
 					card.seal = G.P_SEALS[card.ability.immutable.other_side.seal]
 							and card.ability.immutable.other_side.seal
@@ -2330,6 +2320,14 @@ local double_sided = {
 				return true
 			end
 			return no_suitref(card)
+		end
+
+		local should_hide_frontref = Card.should_hide_front
+		function Card:should_hide_front(...)
+			if self.edition and self.edition.key == "e_cry_double_sided" and not self.base.value then
+				return true
+			end
+			return should_hide_frontref(self, ...)
 		end
 
 		-- 		local calculate_joker = Card.calculate_joker

--- a/lovely/ccd.toml
+++ b/lovely/ccd.toml
@@ -124,7 +124,7 @@ target = "card.lua"
 pattern = '''return generate_card_ui(self.config.center, nil, loc_vars, card_type, badges, hide_desc, main_start, main_end, self)'''
 position = "before"
 payload = '''
-if card_type ~= 'Default' and card_type ~= 'Enhanced' and self.playing_card then -- and card_type ~= 'Joker' then
+if card_type ~= 'Default' and card_type ~= 'Enhanced' and self.playing_card then
 	loc_vars = loc_vars or {}
 	loc_vars.ccd = {
 		playing_card = not not self.base.colour, value = self.base.value, suit = self.base.suit, colour = self.base.colour,

--- a/lovely/ccd.toml
+++ b/lovely/ccd.toml
@@ -143,7 +143,6 @@ pattern = '''local loc_vars = {}'''
 position = "before"
 payload = '''
 if specific_vars and specific_vars.ccd then
-	local debug_table = specific_vars.ccd
 	full_UI_table.ccd = {name = {}, main = {}}
 	localize{type = 'other', key = 'playing_card', set = 'Other', nodes = full_UI_table.ccd.name, vars = {localize(specific_vars.ccd.value, 'ranks'), localize(specific_vars.ccd.suit, 'suits_plural'), colours = {specific_vars.ccd.colour}}}
 	full_UI_table.ccd.name = full_UI_table.ccd.name[1]

--- a/lovely/ccd.toml
+++ b/lovely/ccd.toml
@@ -124,7 +124,7 @@ target = "card.lua"
 pattern = '''return generate_card_ui(self.config.center, nil, loc_vars, card_type, badges, hide_desc, main_start, main_end, self)'''
 position = "before"
 payload = '''
-if card_type ~= 'Default' and card_type ~= 'Enhanced' and self.playing_card then
+if card_type ~= 'Default' and card_type ~= 'Enhanced' and self.playing_card then -- and card_type ~= 'Joker' then
 	loc_vars = loc_vars or {}
 	loc_vars.ccd = {
 		playing_card = not not self.base.colour, value = self.base.value, suit = self.base.suit, colour = self.base.colour,
@@ -143,6 +143,7 @@ pattern = '''local loc_vars = {}'''
 position = "before"
 payload = '''
 if specific_vars and specific_vars.ccd then
+	local debug_table = specific_vars.ccd
 	full_UI_table.ccd = {name = {}, main = {}}
 	localize{type = 'other', key = 'playing_card', set = 'Other', nodes = full_UI_table.ccd.name, vars = {localize(specific_vars.ccd.value, 'ranks'), localize(specific_vars.ccd.suit, 'suits_plural'), colours = {specific_vars.ccd.colour}}}
 	full_UI_table.ccd.name = full_UI_table.ccd.name[1]


### PR DESCRIPTION
This PR makes the following fixes to the functionality of the Double-Sided edition:

1. There exists a fairly glaring visual glitch where the blank side of an unmerged double-faced playing card appears to still have the rank and suit of the front face. This can easily lead to situations where a player gets the two sides confused, which causes all sorts of UX problems. From what I can tell, the cause of the glitch is that (possibly due to some sort of change in Steamodded or Talisman?) the current method of hiding the rank and suit (deleting card.children.front) is ineffective. To fix this, this PR instead hides the rank and suit by hooking Steamodded's provided Card:should_hide_front function to return true for blank faces of umerged double-sided playing cards.
2. If a double-sided playing card is moved to the joker tray with Quantify and merged with a joker, the game crashes upon mousing over the joker side of the resulting hybrid card. The crash happens because the game still considers the hybrid card to be a playing card, so it tries to generate an appropriate tooltip for a playing card, only to fail to find the rank and suit because the joker side doesn't have those. This PR fixes the crash by keeping track of the playing_card field of each face separately, to toggle whether or not a card is considered a playing card depending on which side is in front.