### PR TITLE
Block merging playing cards with non-playing cards

### DIFF
--- a/items/misc.lua
+++ b/items/misc.lua
@@ -2435,6 +2435,7 @@ G.FUNCS.can_merge_ds = function(e)
 		and not other.merged
 		and card.area
 		and card.area.config.type ~= "shop"
+		and (not not card.playing_card) == (not not other.playing_card)
 	then
 		e.config.colour = G.C.PURPLE
 		e.config.button = "merge_ds"


### PR DESCRIPTION
This PR adds a check to can_merge_ds to ensure playing cards cannot be double-sided-merged with non-playing cards, even if they are both in the same card area (e.g. playing card moved to the joker tray with Quantify).

This change entails a bit of a philosophical statement, but I think it's one the Spectralpack team will find sympathetic. From my interactions with members of the dev team on Discord, the double-sided edition is notorious for being an albatross around Cryptid's neck – a massive hassle to code and maintain and extremely liable to glitchy behavior. This particular situation of merging playing cards with non-playing cards represents an entire surface of extremely rare and thorny edge cases that I estimate to be way too much effort to be worth supporting.

For example: multiuse CCDs put in the joker tray with Quantify are returned to your hand upon use. If the CCD in question is double-sided, and was merged with a joker during its visit to the joker tray, flipping the playing card to its joker side results in you having a joker in your hand. This is all the natural consequence of the current mechanics, but the end result is riddled with unanswered design questions. What does it even mean to have a joker in your hand? How is such a thing supposed to behave? What happens if you play it? Under what circumstances should its ability activate?

I suspect the Spectralpack team has no interest in going through the trouble of answering questions like these, especially considering their efforts are currently focused on Cryptid 2. That being the case, I think this whole branch of the state space is best amputated at the source; but I leave it to your judgment to decide.