### PR TITLE
Fix nil card crash in SMODS.is_eternal

### DIFF
--- a/lovely/fix_eternal_nil.toml
+++ b/lovely/fix_eternal_nil.toml
@@ -1,0 +1,15 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+
+# Guard against nil card in SMODS.is_eternal
+# Prevents crash: "attempt to index local 'card' (a nil value)"
+# when SMODS.is_eternal is called with a nil card (e.g. from
+# stake/eternal checks on highlighted hand with empty slots)
+[[patches]]
+[patches.pattern]
+target = '''=[SMODS _ "src/utils.lua"]'''
+pattern = "function SMODS.is_eternal(card, trigger)"
+position = "after"
+payload = "    if not card then return false end"
+match_indent = true


### PR DESCRIPTION
## Description

**Problem:** Game crashes with:
```
main.lua:2122: [SMODS _ "src/utils.lua"]:3000: attempt to index local 'card' (a nil value)
```
when `SMODS.is_eternal(card)` is called with a nil card.

This function is invoked from many locations across the codebase (`G.jokers.cards[i]`, `G.hand.highlighted[i]`, destroy contexts, etc.). Under certain conditions (empty hand, out-of-bounds index, invalid context), the card parameter can be nil.

**Solution:** Added a nil guard via Lovely patch (`fix_eternal_nil.toml`). Returns `false` (safe default — not eternal) for nil cards.
