### PR TITLE
Fixed Oil Lamp blueprint compatibility label

### DIFF
--- a/items/misc_joker.lua
+++ b/items/misc_joker.lua
@@ -9473,6 +9473,7 @@ local oil_lamp = { --You want it? It's yours my friend
 	order = 127,
 	atlas = "atlastwo",
 	demicoloncompat = true,
+	blueprint_compat = false,
 	loc_vars = function(self, info_queue, card)
 		card.ability.blueprint_compat_ui = card.ability.blueprint_compat_ui or ""
 		card.ability.blueprint_compat_check = nil


### PR DESCRIPTION
Blueprint cannot copy Oil Lamp. Looking at Oil Lamp's code, this is clearly intentional, as there is an explicit check that context.blueprint is false before the effect activates. However, because Oil Lamp does not have blueprint_compat defined, the game assumes that Oil Lamp is compatible with Blueprint for the purpose of Blueprint's "compatible"/"incompatible" label.

This PR assigns Oil Lamp's blueprint_compat to false, so that Blueprint -> Oil Lamp is correctly labelled as incompatible.