### PR TITLE
Fixed White Hole setting most played hand to LV2

### DIFF
--- a/items/spectral.lua
+++ b/items/spectral.lua
@@ -1134,7 +1134,8 @@ local white_hole = {
 		local removed_levels = 0
 		for k, v in ipairs(G.handlist) do
 			if to_big(G.GAME.hands[v].level) > to_big(1) then
-				local this_removed_levels = G.GAME.hands[v].level - 1
+				-- coercing to string first is necessary because coercing directly to number returns nil for some reason
+				local this_removed_levels = tonumber(tostring((G.GAME.hands[v].level - 1)))
 				if
 					-- Due to how these poker hands are loaded they still techically exist even if Poker Hand Stuff is disabled
 					-- Because they still exist, While Hole needs to ignore levels from these if disabled (via Black Hole, Planet.lua, etc...)
@@ -1144,7 +1145,6 @@ local white_hole = {
 					if v ~= _hand or not modest then
 						removed_levels = removed_levels + this_removed_levels
 						level_up_hand(used_consumable, v, true, -this_removed_levels)
-						G.GAME.hands[v].level = 1
 					end
 				end
 			end
@@ -1158,8 +1158,7 @@ local white_hole = {
 		if modest then
 			level_up_hand(used_consumable, _hand, false, 4)
 		else
-			local boost = tonumber(tostring(math.min((3 * removed_levels), 1e300)))
-			level_up_hand(used_consumable, _hand, false, boost)
+			level_up_hand(used_consumable, _hand, false, math.min((3 * removed_levels), 1e300))
 		end
 		update_hand_text(
 			{ sound = "button", volume = 0.7, pitch = 1.1, delay = 0 },

--- a/items/spectral.lua
+++ b/items/spectral.lua
@@ -1158,7 +1158,8 @@ local white_hole = {
 		if modest then
 			level_up_hand(used_consumable, _hand, false, 4)
 		else
-			level_up_hand(used_consumable, _hand, false, math.min((3 * removed_levels), 1e300))
+			local boost = tonumber(tostring(math.min((3 * removed_levels), 1e300)))
+			level_up_hand(used_consumable, _hand, false, boost)
 		end
 		update_hand_text(
 			{ sound = "button", volume = 0.7, pitch = 1.1, delay = 0 },


### PR DESCRIPTION
The first successful time you play White Hole (i.e. the first time it removes at least one level), it sets the stats of the most played hand correctly, but the level gets set to 2 instead of whatever it should have been, which has implications for future activations of White Hole. 

This bug bears a striking resemblance to the issue addressed in #834 and #840 where the levels of all the other hands weren't getting reset – and sure enough, it turns out both bugs have the same underlying cause.

The first time White Hole is used, G.GAME.hands[v].level is of type cdata instead of type number, and that type persists across all the arithmetic done on that number. When a cdata value is fed into the "number of levels" argument of level_up_hand and subsequently into SMODS.upgrade_poker_hands, upgrade_poker_hands sets the hand's stats correctly but defaults to incrementing the hand's actual level by 1.

Coercing the value read from G.GAME.hands[v].level to an actual number fixes everything – not only does this remove the "most played hand set to LV2" bug, it also obviates the need for the "manually set the other hands' levels to 1" workaround from #834. This should hopefully be the true end of White Hole's screwy behavior.