### PR TITLE
Fixed Quantify not calling add_to_deck

### DIFF
--- a/items/code.lua
+++ b/items/code.lua
@@ -4060,6 +4060,7 @@ local quantify = {
 						if to_big(G.GAME.dollars - G.GAME.bankrupt_at) < to_big(highlighted.cost) then
 							return
 						end
+						highlighted.add_to_deck(highlighted, nil, false)
 						ease_dollars(-highlighted.cost)
 						highlighted.children.price:remove()
 					end

--- a/items/code.lua
+++ b/items/code.lua
@@ -4060,7 +4060,7 @@ local quantify = {
 						if to_big(G.GAME.dollars - G.GAME.bankrupt_at) < to_big(highlighted.cost) then
 							return
 						end
-						highlighted.add_to_deck(highlighted, nil, false)
+						highlighted:add_to_deck(nil, false)
 						ease_dollars(-highlighted.cost)
 						highlighted.children.price:remove()
 					end


### PR DESCRIPTION
When a joker is moved from the shop to the joker tray, its add_to_deck function is supposed to be called. This is a weight-bearing assumption: jokers like Oops! All Sixes never apply their effects if they never get an add_to_deck call.

Quantify currently does not call add_to_deck on the target card. In many cases this makes sense – if the target card is coming from the joker tray, the consumable area, or your hand, then its add_to_deck function has presumably been called already, such that calling add_to_deck again would be incorrect. But Quantify never calling add_to_deck means that, for example, an Oops! All Sixes moved from the shop to the tray with Quantify will not work.

So to make Quantify work correctly in both cases, this PR adds code to call add_to_deck on the target card if and only if that card has a price defined.