### PR TITLE
Refactored modifications to G.jokers.config.card_limit for a bunch of jokers

### DIFF
--- a/items/epic.lua
+++ b/items/epic.lua
@@ -1897,8 +1897,8 @@ local soccer = {
 	add_to_deck = function(self, card, from_debuff)
 		card.ability.extra.holygrail = math.floor(card.ability.extra.holygrail)
 		local mod = card.ability.extra.holygrail
-		G.jokers.config.card_limit = G.jokers.config.card_limit + ((Card.get_gameset(card) == "modest") and 0 or mod)
-		G.consumeables.config.card_limit = G.consumeables.config.card_limit + mod
+		G.jokers:change_size((Card.get_gameset(card) == "modest") and 0 or mod)
+		G.consumeables:change_size(mod)
 		G.hand:change_size(mod)
 		SMODS.change_booster_limit(mod)
 		SMODS.change_voucher_limit(mod)
@@ -1906,8 +1906,8 @@ local soccer = {
 	remove_from_deck = function(self, card, from_debuff)
 		card.ability.extra.holygrail = math.floor(card.ability.extra.holygrail)
 		local mod = card.ability.extra.holygrail
-		G.jokers.config.card_limit = G.jokers.config.card_limit + ((Card.get_gameset(card) == "modest") and 0 or -mod)
-		G.consumeables.config.card_limit = G.consumeables.config.card_limit - mod
+		G.jokers:change_size((Card.get_gameset(card) == "modest") and 0 or -mod)
+		G.consumeables:change_size(-mod)
 		G.hand:change_size(-mod)
 		SMODS.change_booster_limit(-mod)
 		SMODS.change_voucher_limit(-mod)

--- a/items/epic.lua
+++ b/items/epic.lua
@@ -1532,17 +1532,16 @@ local bonusjoker = {
 						if not context.blueprint then
 							card.ability.immutable.check = lenient_bignum(card.ability.immutable.check + 1)
 						end
-						G.jokers.config.card_limit = lenient_bignum(
-							G.jokers.config.card_limit + math.min(card.ability.extra.add, card.ability.immutable.max)
-						)
+						G.jokers:change_size(lenient_bignum(
+							to_big(math.min(card.ability.extra.add, card.ability.immutable.max))
+						))
 					else
 						if not context.blueprint then
 							card.ability.immutable.check = lenient_bignum(card.ability.immutable.check + 1)
 						end
-						G.consumeables.config.card_limit = lenient_bignum(
-							G.consumeables.config.card_limit
-								+ to_big(math.min(card.ability.extra.add, card.ability.immutable.max))
-						)
+						G.consumeables:change_size(lenient_bignum(
+							to_big(math.min(card.ability.extra.add, card.ability.immutable.max))
+						))
 					end
 					return {
 						extra = { focus = card, message = localize("k_upgrade_ex") },
@@ -1572,17 +1571,16 @@ local bonusjoker = {
 				if not context.blueprint then
 					card.ability.immutable.check = lenient_bignum(card.ability.immutable.check + 1)
 				end
-				G.jokers.config.card_limit = lenient_bignum(
-					G.jokers.config.card_limit + math.min(card.ability.extra.add, card.ability.immutable.max)
-				)
+				G.jokers:change_size(lenient_bignum(
+					to_big(math.min(card.ability.extra.add, card.ability.immutable.max))
+				))
 			else
 				if not context.blueprint then
 					card.ability.immutable.check = lenient_bignum(card.ability.immutable.check + 1)
 				end
-				G.consumeables.config.card_limit = lenient_bignum(
-					G.consumeables.config.card_limit
-						+ to_big(math.min(card.ability.extra.add, card.ability.immutable.max))
-				)
+				G.consumeables:change_size(lenient_bignum(
+					to_big(math.min(card.ability.extra.add, card.ability.immutable.max))
+				))
 			end
 			return {
 				extra = { focus = card, message = localize("k_upgrade_ex") },

--- a/items/epic.lua
+++ b/items/epic.lua
@@ -360,10 +360,10 @@ local negative = {
 		if card.ability.extra.slots > card.ability.immutable.max_slots then
 			card.ability.extra.slots = card.ability.immutable.max_slots
 		end
-		G.jokers.config.card_limit = lenient_bignum(G.jokers.config.card_limit + to_big(card.ability.extra.slots))
+		G.jokers:change_size(lenient_bignum(to_big(card.ability.extra.slots)))
 	end,
 	remove_from_deck = function(self, card, from_debuff)
-		G.jokers.config.card_limit = lenient_bignum(G.jokers.config.card_limit - to_big(card.ability.extra.slots))
+		G.jokers:change_size(lenient_bignum(-to_big(card.ability.extra.slots)))
 	end,
 	cry_credits = {
 		idea = {

--- a/items/exotic.lua
+++ b/items/exotic.lua
@@ -551,14 +551,14 @@ local tenebris = {
 		end
 	end,
 	add_to_deck = function(self, card, from_debuff)
-		G.jokers.config.card_limit = lenient_bignum(
-			G.jokers.config.card_limit + math.min(card.ability.immutable.max_slots, to_big(card.ability.extra.slots))
-		)
+		G.jokers:change_size(
+			lenient_bignum(math.min(card.ability.immutable.max_slots, to_big(card.ability.extra.slots))
+		))
 	end,
 	remove_from_deck = function(self, card, from_debuff)
-		G.jokers.config.card_limit = lenient_bignum(
-			G.jokers.config.card_limit - math.min(card.ability.immutable.max_slots, to_big(card.ability.extra.slots))
-		)
+		G.jokers:change_size(
+			lenient_bignum(- math.min(card.ability.immutable.max_slots, to_big(card.ability.extra.slots))
+		))
 	end,
 	cry_credits = {
 		idea = { "Gold" },

--- a/items/m.lua
+++ b/items/m.lua
@@ -579,7 +579,7 @@ local notebook = {
 					card.ability.extra.add = 0
 				end
 
-				G.jokers.config.card_limit = lenient_bignum(G.jokers.config.card_limit + to_big(card.ability.extra.add))
+				G.jokers:change_size(lenient_bignum(to_big(card.ability.extra.add)))
 				card.ability.extra.check = false
 				card.ability.extra.active = localize("cry_inactive")
 				return {
@@ -612,14 +612,14 @@ local notebook = {
 				card.ability.extra.add = 0
 			end
 
-			G.jokers.config.card_limit = lenient_bignum(G.jokers.config.card_limit + to_big(card.ability.extra.add))
+			G.jokers:change_size(lenient_bignum(to_big(card.ability.extra.add)))
 		end
 	end,
 	add_to_deck = function(self, card, from_debuff)
-		G.jokers.config.card_limit = lenient_bignum(G.jokers.config.card_limit + to_big(card.ability.immutable.slots))
+		G.jokers:change_size(lenient_bignum(to_big(card.ability.immutable.slots)))
 	end,
 	remove_from_deck = function(self, card, from_debuff)
-		G.jokers.config.card_limit = lenient_bignum(G.jokers.config.card_limit - to_big(card.ability.immutable.slots))
+		G.jokers:change_size(lenient_bignum(-to_big(card.ability.immutable.slots)))
 	end,
 	cry_credits = {
 		idea = {

--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -650,7 +650,7 @@ local spy = {
 		end
 	end,
 	add_to_deck = function(self, card, from_debuff)
-		G.jokers.config.card_limit = G.jokers.config.card_limit + 1
+		G.jokers:change_size(1)
 		card.ability.perishable = true
 		card.ability.perish_tally = G.GAME.perishable_rounds
 		card.config.center.rarity = "cry_cursed"
@@ -658,7 +658,7 @@ local spy = {
 		card.ability.extra.revealed = true
 	end,
 	remove_from_deck = function(self, card, from_debuff)
-		G.jokers.config.card_limit = G.jokers.config.card_limit - 1
+		G.jokers:change_size(-1)
 	end,
 	calculate = function(self, card, context)
 		if context.joker_main then


### PR DESCRIPTION
Various jokers in Cryptid have the effect of modifying your joker limit. For example, Negative Joker simply has the effect of adding +4 joker slots. To implement this, these jokers are coded to write to G.jokers.config.card_limit.

However, it turns out this is the wrong way to go about things. It turns out, modifications to G.jokers.config.card_limit get buffered, and are only applied the next time handle_card_limit gets run. If something then reads G.jokers.config.card_limit in the meantime, it'll get a stale value.

There are a whole host of ways this can come up, here are just a few examples:
- Boosting a Negative Joker with Tropical Smoothie removes the old boost at the same time it adds the new boost, which results in the removal of the old boost getting clobbered; that old boost ends up lingering forever.
- If Bonus Joker triggers multiple times in a single hand, and tries to boost the same area limit more than once, extra boosts beyond the first get clobbered, and you only actually get +1 card area size.
- If Nostalgic Googol Play Card creates copies of Tenebris, both new Tenebrises try to apply their boost at the same time, but only one succeeds, resulting in +25 joker slots instead of +50.
- If Gateway destroys multiple joker-limit-boosting jokers at once, only the last such destroyed joker will succeed at removing the joker slots it added; the joker limit boosts from the other applicable jokers persist forever.

The correct way to modify the joker limit (that applies the change immediately rather than buffering the change for later) is to call G.jokers:change_size(). This PR goes through all the jokers that boost the joker limit and refactors them to use G.jokers:change_size().