### PR TITLE
Fix monster exploit

### DIFF
--- a/items/m.lua
+++ b/items/m.lua
@@ -1883,6 +1883,9 @@ local longboi = {
 		end
 	end,
 	set_ability = function(self, card, initial, delay_sprites)
+		if card.cry_flipping then
+			return
+		end
 		local aaa = lenient_bignum(G.GAME and G.GAME.monstermult or 1)
 		if (Cryptid.safe_get(card, "area", "config", "type") or "") == "title" then
 			card.ability.extra.monster = aaa

--- a/items/misc.lua
+++ b/items/misc.lua
@@ -2149,6 +2149,7 @@ local double_sided = {
 		end
 		function Card:flip_side()
 			local card = self
+			card.cry_flipping = true
 			if not card.ability.immutable then
 				card.ability.immutable = {}
 			end
@@ -2253,6 +2254,7 @@ local double_sided = {
 					card.ability.immutable.other_side.base = base
 				end
 			end
+			card.cry_flipping = nil
 		end
 		function Card:get_other_side_dummy(added_to_deck)
 			if self.ability.immutable and type(self.ability.immutable.other_side) == "table" then


### PR DESCRIPTION
Fixes an exploit where Monster can give xmult to itself when it has a double-sided edition by flipping and un-flipping it.