### PR TITLE
Fixed Candy Sticks behavior when spawned mid boss

### DIFF
--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -1940,7 +1940,7 @@ local candy_sticks = {
 	config = {
 		extra = { hands = 1 },
 		immutable = {
-			boss = {},
+			boss = nil,
 			clockscore = 0,
 		},
 	},
@@ -1971,14 +1971,14 @@ local candy_sticks = {
 				end,
 			}))
 		end
-		if context.after and G.GAME.blind:get_type() == "Boss" then
+		if context.after and G.GAME.blind:get_type() == "Boss" and card.ability.immutable.boss then
 			card.ability.extra.hands = lenient_bignum(to_big(card.ability.extra.hands) - 1)
 		end
 		if
 			(
 				(context.selling_self and G.GAME.blind and G.GAME.blind:get_type() == "Boss")
 				or to_big(card.ability.extra.hands) <= to_big(0)
-			) and G.GAME.blind.disabled
+			) and G.GAME.blind.disabled and card.ability.immutable.boss
 		then
 			G.GAME.blind:load(card.ability.immutable.boss)
 			if not context.selling_self then
@@ -2009,7 +2009,7 @@ local candy_sticks = {
 				}
 			end
 		end
-		if context.end_of_round and G.GAME.blind:get_type() == "Boss" then
+		if context.end_of_round and G.GAME.blind:get_type() == "Boss" and card.ability.immutable.boss then
 			G.E_MANAGER:add_event(Event({
 				func = function()
 					play_sound("tarot1")


### PR DESCRIPTION
The joker Candy Sticks has the unique effect of _temporarily_ disabling a boss blind. Neither vanilla Balatro nor Steamodded nor Talisman provides such a mechanic, so the effect was implemented a little bit kludgily. Basically, when a boss blind is selected, Candy Sticks records the details of the boss before disabling it, so that when the effect of the Sticks runs out, the boss blind can be reloaded from the saved data.

This implementation makes the weight-bearing assumption that if a Candy Sticks is in the joker tray during a Boss Blind, it must have been around to see the blind get selected. If a Candy Sticks is created mid-Boss Blind, such as via Candy Basket, that assumption is violated, which causes problems:
- If a Candy Sticks is created mid-Boss Blind, it does not disable the boss, because that only happens during blind selection; yet the Candy Sticks will still be expended upon playing a hand or ending the round, effectively making the Candy Sticks useless.
- If a Candy Sticks is created mid-Boss Blind, the Boss Blind is disabled via another method (such as by selling Luchador), and then the Candy Sticks is sold or expended, it will assume the Boss Blind is only disabled because of its own effect. This prompts the Sticks to reload the blind from an uninitialized internal variable, which crashes the game.

There are a couple different approaches that could be taken to sanitize this edge case. This PR chooses the approach of locking Candy Sticks' effects behind the condition that its internal variable is properly initialized. Thus, a Candy Sticks spawned mid-Boss Blind will not try to disable or re-enable the boss, and it will not be consumed. Effectively, with this alteration, "the next Boss Blind" mentioned in Candy Sticks' text is construed not to refer to a Boss Blind already in progress.