### PR TITLE
Fixed blueprint compat label for Compound Interest and Tax Fraud

### DIFF
--- a/items/misc_joker.lua
+++ b/items/misc_joker.lua
@@ -1278,6 +1278,7 @@ local compound_interest = {
 	rarity = 3,
 	order = 9,
 	cost = 10,
+	blueprint_compat = false,
 	perishable_compat = false,
 	atlas = "atlastwo",
 	loc_vars = function(self, info_queue, center)
@@ -9581,6 +9582,7 @@ local tax_fraud = {
 	cost = 10,
 	order = 128,
 	atlas = "atlastwo",
+	blueprint_compat = false,
 	demicoloncompat = true,
 	in_pool = function(self)
 		if not G.GAME.modifiers.enable_rentals_in_shop then


### PR DESCRIPTION
Blueprint and Brainstorm are not compatible with any joker effect of the form "produce money at payout." This applies to the jokers Tax Fraud and Compound Interest, but those jokers are still visually labeled as being compatible with Blueprint, because they're missing blueprint_compat = false. This PR fixes that oversight.