### PR TITLE
Fixed Burnt Joker retriggers when upgrading None hand

### DIFF
--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -1915,9 +1915,7 @@ G.FUNCS.discard_cards_from_highlighted = function(e, hook)
 			return a.T.x < b.T.x
 		end)
 		check_for_unlock({ type = "discard_custom", cards = {} })
-		for j = 1, #G.jokers.cards do
-			G.jokers.cards[j]:calculate_joker({ pre_discard = true, full_hand = G.hand.highlighted, hook = hook })
-		end
+		SMODS.calculate_context({pre_discard = true, full_hand = G.hand.highlighted, hook = hook})
 		if not hook then
 			if G.GAME.modifiers.discard_cost then
 				ease_dollars(-G.GAME.modifiers.discard_cost)


### PR DESCRIPTION
G.FUNCS.discard_cards_from_highlighted is the function Balatro uses to resolve discards. This includes manual discards as well as forcible discards from The Hook. It is this function's responsibility to trigger joker effects relating to discarding cards, such as Burnt Joker's ability to upgrade the first discarded hand each round.

G.FUNCS.discard_cards_from_highlighted has a failsafe by which joker on-discard effects do not activate if no cards are highlighted, perhaps because the player played all the cards in their hand against The Hook, leaving no cards in hand for The Hook to forcibly discard. This makes sense in a context where the None hand does not exist, since trying to upgrade an indeterminate poker hand would presumably not end well for the game.

However, in the context where None exists (and is unlocked for the profile), it is possible for the player to voluntarily discard a None by clicking the Discard button with no cards selected. In this case, it's important to trigger joker on-discard effects, so that it's possible to use Burnt Joker to upgrade None. This is handled by giving the Discard button a special case for the situation where no cards are highlighted, and manually triggering joker on-discard effects in that case. Trouble is, this manual triggering was implemented in an incomplete fashion – the jokers get triggered, but not in the holistic sense that would allow retriggers to be applied. Therefore, Burnt Joker could not be retriggered by Chad et al when upgrading a None hand, even though Burnt Joker's effect is otherwise eligible to be retriggered.

This PR corrects this mistake by replacing the for loop that sends joker triggers with an SMODS.calculate_context call, since calculate_context serves the same purpose while also resolving retriggers.

(I am left wondering whether it would be smarter to modify G.FUNCS.discard_cards_from_highlighted directly rather than go through this whole workaround, both to avoid inconsistencies like this and to allow Burnt Joker to upgrade None off of The Hook discarding nothing. But that's a question for another time.)