### PR TITLE
Fixed crash when Mr. Bones saves you from Lavender Loop

### DIFF
--- a/items/blind.lua
+++ b/items/blind.lua
@@ -1033,12 +1033,13 @@ local lavender_loop = {
 	cry_round_base_mod = function(self, dt)
 		local aaa = 4 * (G.GAME.modifiers.cry_rush_hour_iii or 1)
 		if
+			G.GAME.cry_ach_conditions.patience_virtue_timer	and
 			G.GAME.cry_ach_conditions.patience_virtue_timer > 0
 			and G.GAME.cry_ach_conditions.patience_virtue_earnable ~= true
 		then
 			G.GAME.cry_ach_conditions.patience_virtue_timer = G.GAME.cry_ach_conditions.patience_virtue_timer
 				- dt * (G.SETTINGS.paused and 0 or 1) * G.SETTINGS.GAMESPEED
-		elseif G.GAME.current_round.hands_played == 0 then
+		elseif G.GAME.current_round.hands_played == 0 and G.GAME.cry_ach_conditions.patience_virtue_timer then
 			G.GAME.cry_ach_conditions.patience_virtue_earnable = true
 		end
 		if G.SETTINGS.paused or G.STATE == G.STATES.HAND_PLAYED then

--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -549,6 +549,7 @@ function Game:update(dt)
 			and G.GAME.blind
 			and not G.GAME.blind.disabled
 			and to_big(G.GAME.chips) < to_big(G.GAME.blind.chips)
+			and G.GAME.current_round.hands_left >= 1
 		then
 			G.GAME.blind.chips = G.GAME.blind.chips
 				* (G.GAME.blind.cry_round_base_mod and G.GAME.blind:cry_round_base_mod(dt) or 1)

--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -549,7 +549,6 @@ function Game:update(dt)
 			and G.GAME.blind
 			and not G.GAME.blind.disabled
 			and to_big(G.GAME.chips) < to_big(G.GAME.blind.chips)
-			and G.GAME.current_round.hands_left >= 1
 		then
 			G.GAME.blind.chips = G.GAME.blind.chips
 				* (G.GAME.blind.cry_round_base_mod and G.GAME.blind:cry_round_base_mod(dt) or 1)


### PR DESCRIPTION
Lavender Loop is a Showdown Blind whose gimmick is that its quota grows exponentially in real time as you play the blind. There exists a special achievement "Patience is a Virtue" earned by waiting two minutes before playing your first hand, thereby allowing the quota to scale significantly. To keep track of this, the game initializes the variable G.GAME.cry_ach_conditions.patience_virtue_timer when the blind is selected, counts down the variable while playing the blind, and resets the variable to nil at the end of the round immediately after checking to see if the achievement should be granted.

This control flow assumes as a precondition that G.GAME.cry_ach_conditions.patience_virtue_timer is not nil when cry_round_base_mod is called to scale the quota. If the timer is nil, the game tries to do arithmetic on nil and crashes. Looking at where cry_round_base_mod gets called, there's a check to make sure the player hasn't earned enough chips to beat the blind before calling it; but it turns out this isn't enough to ensure the precondition is satisfied, because effects like Mr. Bones and (force-triggered) Semicolon can bring the player to the end-of-round state without meeting the blind quota. In these cases, cry_round_base_mod gets called after G.GAME.cry_ach_conditions.patience_virtue_timer has been cleared, crashing the game.

This PR adds nil guards to Lavender Loop's cry_round_base_mod function, allowing it to work correctly even when the precondition is not satisfied.