### PR TITLE
Fix Broken Sync Catalyst setting values to 0

### DIFF
--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -2187,6 +2187,7 @@ function SMODS.calculate_individual_effect(effect, scored_card, key, amount, fro
 		local chip_mod = chips.current * amount
 		local mult_mod = mult.current * amount
 
+		-- modifications are done in two steps to avoid rounding errors
 		chips:modify(-chip_mod)
 		chips:modify(mult_mod)
 		mult:modify(-mult_mod)

--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -2187,8 +2187,10 @@ function SMODS.calculate_individual_effect(effect, scored_card, key, amount, fro
 		local chip_mod = chips.current * amount
 		local mult_mod = mult.current * amount
 
-		chips:modify(mult_mod - chip_mod)
-		mult:modify(chip_mod - mult_mod)
+		chips:modify(-chip_mod)
+		chips:modify(mult_mod)
+		mult:modify(-mult_mod)
+		mult:modify(chip_mod)
 
 		if key == "cry_broken_swap" and not Cryptid.safe_get(Talisman, "config_file", "disable_anims") then
 			G.E_MANAGER:add_event(Event({

--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -2188,9 +2188,9 @@ function SMODS.calculate_individual_effect(effect, scored_card, key, amount, fro
 		local mult_mod = mult.current * amount
 
 		-- modifications are done in two steps to avoid rounding errors
-		chips:modify(-chip_mod)
+		chips.current = chips.current * (1 - amount)
 		chips:modify(mult_mod)
-		mult:modify(-mult_mod)
+		mult.current = mult.current * (1 - amount)
 		mult:modify(chip_mod)
 
 		if key == "cry_broken_swap" and not Cryptid.safe_get(Talisman, "config_file", "disable_anims") then


### PR DESCRIPTION
Broken Sync Catalyst is a joker with the effect of swapping a fraction of current chips with a fraction of current mult (10% of each by default). To do this, it calculates the net change for each value, then each value gets added to by its corresponding net change.

However, Broken Sync Catalyst's name happens to be a little too accurate, because when hyper-E values are involved, rounding errors can erroneously set values to 0. For example, if BSC triggers when chips are 50 and mult is ee300, chips are increased by 10% * ee300 - 5 and mult is decreased by the same amount. However, the game's representation of hyper-E notation is not precise enough to distinguish between 10% * ee300 - 5 and ee300 itself, so ee300 - (10% * ee300 - 5) is calculated to be 0, even though the actual value of the expression is basically still ee300.

What this PR does is handle the reduction from Broken Sync Catalyst by multiplication rather than subtraction, because ee300 * 0.9 resolves to ee300 in contrast to how ee300 - (ee300 * 0.1) resolves to 0. The addition is done as a second step afterwards. This implementation is admittedly uglier than I'd like, but I don't know the SMODS and Talismans APIs well enough to know if they offer a better solution. Regardless, I can confirm this version handles hyper-E values appropriately.