### PR TITLE
Fixed infinite loop when banana voucher unredeem probability is 100%

### DIFF
--- a/lib/modifiers.lua
+++ b/lib/modifiers.lua
@@ -748,6 +748,9 @@ SMODS.Sticker({
 						"Banana Sticker"
 					)
 				then
+					if card.display_only then
+						return
+					end
 					local area
 					if G.STATE == G.STATES.HAND_PLAYED then
 						if not G.redeemed_vouchers_during_hand then
@@ -765,6 +768,7 @@ SMODS.Sticker({
 					end
 
 					local _card = copy_card(card)
+					_card.display_only = true
 					_card.ability.extra = copy_table(card.ability.extra)
 					if _card.facing == "back" then
 						_card:flip()

--- a/lib/modifiers.lua
+++ b/lib/modifiers.lua
@@ -738,7 +738,7 @@ SMODS.Sticker({
 			and not context.playing_card_end_of_round
 			and not context.individual
 		then
-			if card.ability.set == "Voucher" then
+			if card.ability.set == "Voucher" and not card.display_only then
 				if
 					SMODS.pseudorandom_probability(
 						card,
@@ -748,9 +748,6 @@ SMODS.Sticker({
 						"Banana Sticker"
 					)
 				then
-					if card.display_only then
-						return
-					end
 					local area
 					if G.STATE == G.STATES.HAND_PLAYED then
 						if not G.redeemed_vouchers_during_hand then


### PR DESCRIPTION
Vouchers with the Banana sticker have a 1 in 12 probability to be unredeemed at the end of each round. If this probability hits, a copy of the voucher is created to display to the screen so that the player knows which voucher they just lost. This copy is placed in the card area G.play to present it front and center on the screen.

This presents a problem: G.play is one of the card areas that gets evaluated during the end of round context calculation, and in fact G.play gets evaluated after vouchers. What this means is that the newly created copy voucher shows up just in time to itself receive the end of round evaluation, including the banana unredeem roll. If enough copies of Oops All Sixes are present to drive the unredeem chance up to 100%, this forms an infinite loop of banana vouchers creating more banana vouchers, which consumes all available memory and unceremoniously kills the game.

This PR fixes this loop by bestowing the created copy with a special display_only flag which exempts it from the end of round banana voucher check.