### PR TITLE
Antimatter deck selection fix

### DIFF
--- a/lib/content.lua
+++ b/lib/content.lua
@@ -849,14 +849,14 @@ function Cryptid.antimatter_compat(key, on_load)
 		not back
 		or back.set ~= "Back"
 		or (SMODS.Centers[key] and Cryptid.enabled(key) ~= true)
-		or not (Cryptid.gameset(G.P_CENTERS.b_cry_antimatter) == "madness" or (Cryptid.safe_get(
+		or not (Cryptid.gameset(G.P_CENTERS.b_cry_antimatter) == "madness" or ((Cryptid.safe_get(
 			G.PROFILES,
 			G.SETTINGS.profile,
 			"deck_usage",
-			back,
+			key,
 			"wins",
 			8
-		) or 0 ~= 0) or on_load)
+		) or 0) ~= 0) or on_load)
 		or not (back.unlocked or on_load)
 	then
 		return false

--- a/lib/ui.lua
+++ b/lib/ui.lua
@@ -37,7 +37,7 @@ SMODS.DrawStep({
 			or false
 		local back = self.ability.set == "Back" and in_run_setup and self.config.center or G.GAME.selected_back_key
 		--or Cryptid.safe_get(G.GAME, "viewed_back", "effect", "center"); fix later
-		if back and (self.config.center == back and back.unlocked or not in_run_setup) then
+		if not self.cry_antimatter_locked and back and (self.config.center == back and back.unlocked or not in_run_setup) then
 			if back.key == "b_cry_antimatter" then
 				self.children.back:draw_shader("negative", nil, self.ARGS.send_to_shader, true)
 				self.children.back:draw_shader("negative_shine", nil, self.ARGS.send_to_shader, true)


### PR DESCRIPTION
Fixes a mistake in code so that the antimatter deck selection works properly on non-madness gamesets now.
<sup>wow I wonder why noone caught this bug before /s 🫠</sup>