### PR TITLE
Fix Booster Packs not spawning in shops on Deck of Equilibrium on non-Madness

### DIFF
--- a/lib/overrides.lua
+++ b/lib/overrides.lua
@@ -81,7 +81,7 @@ function get_current_pool(_type, _rarity, _legendary, _append, override_equilibr
 			for _, id in ipairs(valid_pools) do
 				for k, v in pairs(G.P_CENTER_POOLS[id]) do
 					if
-						v.unlocked == true
+						v.unlocked ~= false
 						and not Cryptid.no(v, "doe", k)
 						and not (G.GAME.banned_keys[v.key] or G.GAME.cry_banished_keys[v.key])
 					then


### PR DESCRIPTION
Fixes an issue where Booster Packs (both vanilla and custom Cryptid boosters) would fail to spawn in shops when playing with the Deck of Equilibrium on profiles without Unlock All (such as Modest ruleset profiles).
### Root Cause
In `lib/overrides.lua`, `get_current_pool` for the Deck of Equilibrium filtered items using `v.unlocked == true`. In Balatro, Booster Packs do not have an `unlocked` property (`unlocked = nil`). 
- On Madness profiles, "Unlock All" runs on startup and explicitly sets `v.unlocked = true` on all centers in `G.P_CENTERS`, masking the issue.
- On non-madness profiles, `v.unlocked` remains `nil` for booster packs, causing `v.unlocked == true` to evaluate to `false` and exclude 100% of booster packs from `P_CRY_ITEMS`.
### Fix
Changed `v.unlocked == true` to `v.unlocked ~= false` in `lib/overrides.lua`. This allows items with `unlocked = nil` (like Booster Packs) to be included while preserving lock status for items with `unlocked = false`.