### PR TITLE
Yet another DoE fix

### DIFF
--- a/lib/misc.lua
+++ b/lib/misc.lua
@@ -457,7 +457,7 @@ function Cryptid.bonus_voucher_mod(mod)
 					G.shop_vouchers.T.y,
 					G.CARD_W,
 					G.CARD_H,
-					G.P_CARDS.empty,
+					(G.P_CENTERS[curr_bonus[#curr_bonus]].set == "Default" or G.P_CENTERS[curr_bonus[#curr_bonus]].set == "Enhanced" or G.P_CENTERS[curr_bonus[#curr_bonus]].key == "c_base") and pseudorandom_element(G.P_CARDS, "cry_equifrontbrium") or G.P_CARDS.empty,
 					G.P_CENTERS[curr_bonus[#curr_bonus]],
 					{ bypass_discovery_center = true, bypass_discovery_ui = true }
 				)
@@ -473,7 +473,7 @@ function Cryptid.bonus_voucher_mod(mod)
 				then
 					card.cry_flipped = true
 				end
-				create_shop_card_ui(card, "Voucher", G.shop_vouchers)
+				create_shop_card_ui(card, (card.config.center.set == "Default" or card.config.center.set == "Enhanced" or card.config.center.key == "c_base") and "Base" or card.config.center.set, G.shop_vouchers)
 				card:start_materialize()
 				if G.GAME.current_round.cry_voucher_edition then
 					card:set_edition(G.GAME.current_round.cry_voucher_edition, true, true)

--- a/lib/misc.lua
+++ b/lib/misc.lua
@@ -457,7 +457,7 @@ function Cryptid.bonus_voucher_mod(mod)
 					G.shop_vouchers.T.y,
 					G.CARD_W,
 					G.CARD_H,
-					(G.P_CENTERS[curr_bonus[#curr_bonus]].set == "Default" or G.P_CENTERS[curr_bonus[#curr_bonus]].set == "Enhanced" or G.P_CENTERS[curr_bonus[#curr_bonus]].key == "c_base") and pseudorandom_element(G.P_CARDS, "cry_equifrontbrium") or G.P_CARDS.empty,
+					G.P_CARDS.empty,
 					G.P_CENTERS[curr_bonus[#curr_bonus]],
 					{ bypass_discovery_center = true, bypass_discovery_ui = true }
 				)
@@ -473,7 +473,7 @@ function Cryptid.bonus_voucher_mod(mod)
 				then
 					card.cry_flipped = true
 				end
-				create_shop_card_ui(card, (card.config.center.set == "Default" or card.config.center.set == "Enhanced" or card.config.center.key == "c_base") and "Base" or card.config.center.set, G.shop_vouchers)
+				create_shop_card_ui(card, "Voucher", G.shop_vouchers)
 				card:start_materialize()
 				if G.GAME.current_round.cry_voucher_edition then
 					card:set_edition(G.GAME.current_round.cry_voucher_edition, true, true)

--- a/lovely/equilibrium.toml
+++ b/lovely/equilibrium.toml
@@ -9,5 +9,41 @@ priority = -1
 target = "game.lua"
 pattern = "G.shop_booster.T.y, G.CARD_W*1.27, G.CARD_H*1.27, G.P_CARDS.empty, G.P_CENTERS[G.GAME.current_round.used_packs[i]], {bypass_discovery_center = true, bypass_discovery_ui = true})"
 position = "at"
-payload = "G.shop_booster.T.y, G.CARD_W*(G.P_CENTERS[G.GAME.current_round.used_packs[i]].set == 'Booster' and 1.27 or 1), G.CARD_H*(G.P_CENTERS[G.GAME.current_round.used_packs[i]].set == 'Booster' and 1.27 or 1), G.P_CARDS.empty, G.P_CENTERS[G.GAME.current_round.used_packs[i]], {bypass_discovery_center = true, bypass_discovery_ui = true})"
+payload = "G.shop_booster.T.y, G.CARD_W*(G.P_CENTERS[G.GAME.current_round.used_packs[i]].set == 'Booster' and 1.27 or 1), G.CARD_H*(G.P_CENTERS[G.GAME.current_round.used_packs[i]].set == 'Booster' and 1.27 or 1), (G.P_CENTERS[G.GAME.current_round.used_packs[i]].set == 'Default' or G.P_CENTERS[G.GAME.current_round.used_packs[i]].set == 'Enhanced' or G.P_CENTERS[G.GAME.current_round.used_packs[i]].key == 'c_base') and pseudorandom_element(G.P_CARDS, 'cry_equifrontbrium') or G.P_CARDS.empty, G.P_CENTERS[G.GAME.current_round.used_packs[i]], {bypass_discovery_center = true, bypass_discovery_ui = true})"
+match_indent = true
+
+# non-pack type in pack slots
+[[patches]]
+[patches.pattern]
+target = "game.lua"
+pattern = "create_shop_card_ui(card, 'Booster', G.shop_booster)"
+position = "at"
+payload = "create_shop_card_ui(card, (card.config.center.set == 'Default' or card.config.center.set == 'Enhanced' or card.config.center.key == 'c_base') and 'Base' or card.config.center.set, G.shop_booster)"
+match_indent = true
+
+# non-voucher front card in SMODS voucher shop slots
+[[patches]]
+[patches.pattern]
+target = '=[SMODS _ "src/utils.lua"]'
+pattern = "G.shop_vouchers.T.y, G.CARD_W, G.CARD_H, G.P_CARDS.empty, G.P_CENTERS[key],{bypass_discovery_center = true, bypass_discovery_ui = true})"
+position = "at"
+payload = "G.shop_vouchers.T.y, G.CARD_W, G.CARD_H, (G.P_CENTERS[key].set == 'Default' or G.P_CENTERS[key].set == 'Enhanced' or G.P_CENTERS[key].key == 'c_base') and pseudorandom_element(G.P_CARDS, 'cry_equifrontbrium') or G.P_CARDS.empty, G.P_CENTERS[key],{bypass_discovery_center = true, bypass_discovery_ui = true})"
+match_indent = true
+
+# non-voucher type in SMODS voucher shop slots
+[[patches]]
+[patches.pattern]
+target = '=[SMODS _ "src/utils.lua"]'
+pattern = "create_shop_card_ui(card, 'Voucher', G.shop_vouchers)"
+position = "at"
+payload = "create_shop_card_ui(card, (card.config.center.set == 'Default' or card.config.center.set == 'Enhanced' or card.config.center.key == 'c_base') and 'Base' or card.config.center.set, G.shop_vouchers)"
+match_indent = true
+
+# non-voucher front card in bonus voucher shop slots (game.lua)
+[[patches]]
+[patches.pattern]
+target = "game.lua"
+pattern = "G.shop_vouchers.T.y, G.CARD_W, G.CARD_H, G.P_CARDS.empty, G.P_CENTERS[G.GAME.current_round.cry_bonusvouchers[i]],{bypass_discovery_center = true, bypass_discovery_ui = true})"
+position = "at"
+payload = "G.shop_vouchers.T.y, G.CARD_W, G.CARD_H, (G.P_CENTERS[G.GAME.current_round.cry_bonusvouchers[i]].set == 'Default' or G.P_CENTERS[G.GAME.current_round.cry_bonusvouchers[i]].set == 'Enhanced' or G.P_CENTERS[G.GAME.current_round.cry_bonusvouchers[i]].key == 'c_base') and pseudorandom_element(G.P_CARDS, 'cry_equifrontbrium') or G.P_CARDS.empty, G.P_CENTERS[G.GAME.current_round.cry_bonusvouchers[i]],{bypass_discovery_center = true, bypass_discovery_ui = true})"
 match_indent = true


### PR DESCRIPTION
### Summary
On the **Deck of Equilibrium** (`cry_equilibrium`), non-booster and non-voucher items (such as playing cards, Jokers, and Consumables) can be drawn into shop booster pack slots (`G.shop_booster`) and shop voucher slots (`G.shop_vouchers`). 
Previously, when playing cards were instantiated in these slots, `G.P_CARDS.empty` was passed as the `front` card, and `create_shop_card_ui` was hardcoded to `'Booster'` or `'Voucher'`. This resulted in:
1. **Rankless/Suitless Cards**: Playing cards spawned with `card.base.value == nil` and `card.base.suit == nil`.
2. **Visual & UI Anomalies**: Playing cards in booster slots were scaled to Booster pack dimensions (`1.27` scaling) and received incorrect shop UI tags/buttons.
3. **Game Crash on Hover**: Hovering over a rankless playing card in hand after applying a CCD effect (e.g., via Hammerspace) caused a Lua crash in `functions/misc_functions.lua` (`localize(nil, 'ranks')` -> `attempt to index local 'args' (a nil value)`).
### Changes Made
- **`lovely/equilibrium.toml`**:
  - Updated `game.lua` patch for `G.shop_booster` card creation so playing cards receive a valid front card (`pseudorandom_element(G.P_CARDS, 'cry_equifrontbrium')`) instead of `G.P_CARDS.empty`.
  - Added patch for `create_shop_card_ui` in `G.shop_booster` to pass the card's true set (`'Base'`, `'Joker'`, etc.) instead of hardcoded `'Booster'`.
  - Added patches for `SMODS.add_voucher_to_shop` (`src/utils.lua`) and `game.lua` bonus voucher slots so non-voucher items in `G.shop_vouchers` receive valid front cards and proper card set UI.
- **`lib/misc.lua`**:
  - Updated `Cryptid.bonus_voucher_mod` to assign valid front cards and card set UI when spawning bonus items into shop voucher slots.