### PR TITLE
Fix a mistake in antimatter deck logic

### DIFF
--- a/items/deck.lua
+++ b/items/deck.lua
@@ -102,6 +102,7 @@ local misprint = {
 		G.GAME.modifiers.cry_misprint_max = (G.GAME.modifiers.cry_misprint_max or 1) * self.config.cry_misprint_max
 	end,
 	cry_antimatter_apply = function(self)
+		G.GAME.modifiers.cry_misprint_min = G.GAME.modifiers.cry_misprint_min or 1
 		G.GAME.modifiers.cry_misprint_max = (G.GAME.modifiers.cry_misprint_max or 1) * self.config.cry_misprint_max
 	end,
 	unlocked = false,


### PR DESCRIPTION
This fix allows poker hands to have randomized values if you apply misprint deck