### PR TITLE
Fix logic in gameset.lua

### DIFF
--- a/lib/gameset.lua
+++ b/lib/gameset.lua
@@ -616,7 +616,14 @@ function Card:set_ability(center, y, z)
 				if k == "cost" then
 					self.base_cost = v
 				else
-					self.ability[k] = v
+					if type(v) == "table" and type(self.ability[k]) == "table" then
+						self.ability[k] = copy_table(self.ability[k])
+						for k2, v2 in pairs(v) do
+							self.ability[k][k2] = type(v2) == "table" and copy_table(v2) or v2
+						end
+					else
+						self.ability[k] = type(v) == "table" and copy_table(v) or v
+					end
 				end
 			end
 		end


### PR DESCRIPTION
Fixes an issue where gameset_config sub-tables (such as extra) were assigned to card abilities by reference instead of being deep-copied/merged.

Because tables were shared by reference, prototype initialization and card scaling mutated gameset_config entries globally in memory during game startup. In particular, this caused the m joker to scale by +13 Xmult on Modest gameset instead of +1 Xmult.