### PR TITLE
Fix the boss blind check logic

### DIFF
--- a/items/code.lua
+++ b/items/code.lua
@@ -4552,7 +4552,7 @@ local semicolon = {
 	atlas = "atlasnotjokers",
 	order = 432,
 	can_use = function(self, card)
-		return G.STATE == G.STATES.SELECTING_HAND and not G.GAME.blind.boss
+		return G.STATE == G.STATES.SELECTING_HAND and not Cryptid.is_boss_blind(G.GAME.blind)
 	end,
 	use = function(self, card, area, copier)
 		G.E_MANAGER:add_event(
@@ -4879,7 +4879,7 @@ local CodeJoker = {
 		if
 			context.setting_blind
 			and not (context.blueprint_card or self).getting_sliced
-			and (G.GAME.blind:get_type() == "Boss" or Cryptid.gameset(card) ~= "exp_modest")
+			and (Cryptid.is_boss_blind(G.GAME.blind) or Cryptid.gameset(card) ~= "exp_modest")
 		then
 			play_sound("timpani")
 			local card = create_card("Code", G.consumeables, nil, nil, nil, nil)

--- a/items/epic.lua
+++ b/items/epic.lua
@@ -1952,7 +1952,7 @@ local fleshpanopticon = {
 		return { vars = { center.ability.extra.boss_size } }
 	end,
 	calculate = function(self, card, context)
-		if context.setting_blind and not context.blueprint and context.blind.boss and not card.getting_sliced then
+		if context.setting_blind and not context.blueprint and Cryptid.is_boss_blind(context.blind) and not card.getting_sliced then
 			local eval = function(card)
 				return not card.REMOVED and not G.RESET_JIGGLES
 			end
@@ -1980,7 +1980,7 @@ local fleshpanopticon = {
 			and not context.individual
 			and not context.repetition
 			and not context.blueprint
-			and G.GAME.blind.boss
+			and Cryptid.is_boss_blind(G.GAME.blind)
 			and not card.gone
 		then
 			G.E_MANAGER:add_event(Event({

--- a/items/joker_display.lua
+++ b/items/joker_display.lua
@@ -1258,7 +1258,7 @@ if JokerDisplay then
 			},
 		},
 		calc_function = function(card)
-			local is_boss = G.GAME and G.GAME.blind and G.GAME.blind.get_type and G.GAME.blind:get_type() == "Boss"
+			local is_boss = Cryptid.is_boss_blind and Cryptid.is_boss_blind(G.GAME.blind) or (G.GAME and G.GAME.blind and G.GAME.blind.get_type and G.GAME.blind:get_type() == "Boss")
 			card.joker_display_values.x_mult = is_boss and card.ability.extra.x_mult or 1
 		end,
 	}

--- a/items/misc_joker.lua
+++ b/items/misc_joker.lua
@@ -2670,7 +2670,7 @@ local apjoker = {
 		return { vars = { number_format(center.ability.extra.x_mult) } }
 	end,
 	calculate = function(self, card, context)
-		if (context.joker_main and G.GAME.blind.boss) or context.forcetrigger then
+		if (context.joker_main and Cryptid.is_boss_blind(G.GAME.blind)) or context.forcetrigger then
 			return {
 				xmult = lenient_bignum(card.ability.extra.x_mult),
 			}
@@ -4102,11 +4102,11 @@ local rnjoker = {
 									end
 								end
 							elseif j.cond == "boss" then
-								if context.blind.boss and not (context.blind.config and context.blind.config.bonus) then
+								if Cryptid.is_boss_blind(context.blind) and not (context.blind.config and context.blind.config.bonus) then
 									cond_passed = true
 								end
 							elseif j.cond == "non_boss" then
-								if context.blind and not G.GAME.blind.boss then
+								if context.blind and not Cryptid.is_boss_blind(context.blind) then
 									cond_passed = true
 								end
 							elseif j.cond == "small" then
@@ -4612,7 +4612,7 @@ local rnjoker = {
 			and not card.debuff
 			and context.end_of_round
 			and not context.blueprint
-			and G.GAME.blind.boss
+			and Cryptid.is_boss_blind(G.GAME.blind)
 			and not (G.GAME.blind.config and G.GAME.blind.config.bonus)
 		then
 			local hand_size = 0
@@ -8028,7 +8028,7 @@ local kscope = {
 		if
 			(
 				context.end_of_round
-				and G.GAME.blind.boss
+				and Cryptid.is_boss_blind(G.GAME.blind)
 				and not context.individual
 				and not context.repetition
 				and not context.blueprint
@@ -8894,7 +8894,7 @@ local carved_pumpkin = {
 	end,
 	calculate = function(self, card, context)
 		if context.end_of_round and not context.blueprint and not context.individual and not context.repetition then
-			if G.GAME.blind:get_type() == "Boss" then
+			if Cryptid.is_boss_blind(G.GAME.blind) then
 				card.ability.extra.disables = lenient_bignum(to_big(card.ability.extra.disables) - 1)
 				card:juice_up()
 				if card.ability.extra.disables <= 0 then
@@ -8902,7 +8902,7 @@ local carved_pumpkin = {
 				end
 			end
 		end
-		if context.setting_blind and G.GAME.blind:get_type() == "Boss" and not G.GAME.blind.disabled then
+		if context.setting_blind and Cryptid.is_boss_blind(G.GAME.blind) and not G.GAME.blind.disabled then
 			card_eval_status_text(
 				context.blueprint_card or card,
 				"extra",

--- a/items/sleeve.lua
+++ b/items/sleeve.lua
@@ -402,7 +402,7 @@ if CardSleeves then
 			return { vars = {} }
 		end,
 		trigger_effect = function(self, args)
-			if args.context == "eval" and G.GAME.last_blind and G.GAME.last_blind.boss then
+			if args.context == "eval" and G.GAME.last_blind and Cryptid.is_boss_blind(G.GAME.last_blind) then
 				if G.jokers then
 					if #G.jokers.cards < G.jokers.config.card_limit then
 						if

--- a/items/spooky.lua
+++ b/items/spooky.lua
@@ -142,7 +142,7 @@ local choco_dice = {
 			and not context.repetition
 			and not context.blueprint
 			and not context.retrigger_joker
-			and G.GAME.blind.boss
+			and Cryptid.is_boss_blind(G.GAME.blind)
 		then
 			--todo: check if duplicates of event are already started/finished
 			SMODS.Events["ev_cry_choco" .. card.ability.extra.roll]:finish()
@@ -943,7 +943,7 @@ local candy_basket = {
 		if context.end_of_round and not context.individual and not context.repetition then
 			card.ability.immutable.current_win_count = card.ability.immutable.current_win_count + 1
 
-			if G.GAME.blind.boss then
+			if Cryptid.is_boss_blind(G.GAME.blind) then
 				SMODS.scale_card(card, {
 					ref_table = card.ability.extra,
 					ref_value = "candies",
@@ -1704,7 +1704,7 @@ local jawbreaker = {
 			context.end_of_round
 			and not context.individual
 			and not context.repetition
-			and G.GAME.blind.boss
+			and Cryptid.is_boss_blind(G.GAME.blind)
 			and not context.blueprint_card
 			and not context.retrigger_joker
 		then
@@ -1990,7 +1990,7 @@ local candy_sticks = {
 	eternal_compat = false,
 	no_dbl = true,
 	calculate = function(self, card, context)
-		if context.setting_blind and not self.getting_sliced and not context.blueprint and context.blind.boss then
+		if context.setting_blind and not self.getting_sliced and not context.blueprint and Cryptid.is_boss_blind(context.blind) then
 			card.ability.immutable.boss = G.GAME.blind:save()
 			if G.GAME.blind.name == "The Clock" then
 				card.ability.immutable.clockscore = G.GAME.blind.chips
@@ -2010,12 +2010,12 @@ local candy_sticks = {
 				end,
 			}))
 		end
-		if context.after and G.GAME.blind:get_type() == "Boss" and card.ability.immutable.boss then
+		if context.after and Cryptid.is_boss_blind(G.GAME.blind) and card.ability.immutable.boss then
 			card.ability.extra.hands = lenient_bignum(to_big(card.ability.extra.hands) - 1)
 		end
 		if
 			(
-				(context.selling_self and G.GAME.blind and G.GAME.blind:get_type() == "Boss")
+				(context.selling_self and G.GAME.blind and Cryptid.is_boss_blind(G.GAME.blind))
 				or to_big(card.ability.extra.hands) <= to_big(0)
 			)
 			and G.GAME.blind.disabled
@@ -2050,7 +2050,7 @@ local candy_sticks = {
 				}
 			end
 		end
-		if context.end_of_round and G.GAME.blind:get_type() == "Boss" and card.ability.immutable.boss then
+		if context.end_of_round and Cryptid.is_boss_blind(G.GAME.blind) and card.ability.immutable.boss then
 			G.E_MANAGER:add_event(Event({
 				func = function()
 					play_sound("tarot1")

--- a/lib/misc.lua
+++ b/lib/misc.lua
@@ -31,6 +31,14 @@ function Cryptid.is_number(v)
 	return type(v) == "number" or Cryptid.is_big(v)
 end
 
+function Cryptid.is_boss_blind(blind)
+	blind = blind or (G.GAME and G.GAME.blind)
+	if not blind then
+		return false
+	end
+	return not not (blind.boss or (blind.config and blind.config.blind and blind.config.blind.boss))
+end
+
 -- More advanced version of find joker for things that need to find very specific things
 function Cryptid.advanced_find_joker(name, rarity, edition, ability, non_debuff, area)
 	local jokers = {}

--- a/lovely/misc.toml
+++ b/lovely/misc.toml
@@ -34,7 +34,7 @@ target = "card.lua"
 pattern = "if self.ability.name == 'Campfire' and G.GAME.blind.boss and self.ability.x_mult > 1 then"
 position = "at"
 payload = '''
-if self.ability.name == 'Campfire' and G.GAME.blind.boss and not (G.GAME.blind.config and G.GAME.blind.config.bonus) and to_big(self.ability.x_mult) > to_big(1) then
+if self.ability.name == 'Campfire' and Cryptid.is_boss_blind(G.GAME.blind) and not (G.GAME.blind.config and G.GAME.blind.config.bonus) and to_big(self.ability.x_mult) > to_big(1) then
 '''
 match_indent = true
 


### PR DESCRIPTION
Change the way that Cryptid checks whether a blind is a boss blind or not to account for boss blinds that replace the regular blinds(like in challenges and high stakes shenanigans)