### PR TITLE
Update smods version and scaling jokers code

### DIFF
--- a/Cryptid.json
+++ b/Cryptid.json
@@ -12,7 +12,7 @@
 	"version": "0.5.17~dev",
 	"dependencies": [
 		"Amulet (>=2.7)",
-		"Steamodded (>=1.0.0~BETA-1925a)"
+		"Steamodded (>=1.0.0~BETA-2008b)"
 	],
 	"conflicts": [
 		"AntePreview (>= 2.0.0~0c16a) (<<3.0.0)",

--- a/items/epic.lua
+++ b/items/epic.lua
@@ -1019,29 +1019,32 @@ local double_scale = {
 	cost = 18,
 	immutable = true,
 	atlas = "atlasepic",
-	calc_scaling = function(self, card, other, current_scaling, current_scalar, args)
-		-- store original scaling rate
-		if not other.ability.cry_scaling_info then
-			other.ability.cry_scaling_info = {
-				[args.scalar_value] = current_scalar,
-			}
-		elseif not other.ability.cry_scaling_info[args.scalar_value] then
-			other.ability.cry_scaling_info[args.scalar_value] = current_scalar
-		end
+	calculate = function(self, card, context)
+		if context.scaling_card then
+			local other = context.card
+			-- store original scaling rate
+			if not other.ability.cry_scaling_info then
+				other.ability.cry_scaling_info = {
+					[context.scalar_value] = context.scalar,
+				}
+			elseif not other.ability.cry_scaling_info[context.scalar_value] then
+				other.ability.cry_scaling_info[context.scalar_value] = context.scalar
+			end
 
-		local original_scalar = other.ability.cry_scaling_info[args.scalar_value]
+			local original_scalar = other.ability.cry_scaling_info[context.scalar_value]
 
-		-- joker scaling stuff
-		if Cryptid.gameset(self) == "exp_modest" then
-			return {
-				scalar_value = lenient_bignum(to_big(original_scalar) * 2),
-				message = localize("k_upgrade_ex"),
-			}
-		else
-			args.scalar_table[args.scalar_value] = current_scalar + original_scalar
-			return {
-				message = localize("k_upgrade_ex"),
-			}
+			-- joker scaling stuff
+			if Cryptid.gameset(self) == "exp_modest" then
+				return {
+					override_scalar_value = lenient_bignum(to_big(original_scalar) * 2),
+					message = localize("k_upgrade_ex"),
+				}
+			else
+				context.scalar_table[context.scalar_value] = context.scalar + original_scalar
+				return {
+					message = localize("k_upgrade_ex"),
+				}
+			end
 		end
 	end,
 	cry_credits = {

--- a/items/exotic.lua
+++ b/items/exotic.lua
@@ -695,42 +695,43 @@ local scalae = {
 				message_colour = G.C.DARK_EDITION,
 			})
 		end
-	end,
-	calc_scaling = function(self, card, other, current_scaling, current_scalar, args)
-		-- checks if the scaled joker is also a scalae
-		-- if so, return nothing
-		if other.config.center.key == self.key then
-			return
-		end
+		if context.scaling_card then
+			local other = context.card
+			-- checks if the scaled joker is also a scalae
+			-- if so, return nothing
+			if other.config.center.key == self.key then
+				return
+			end
 
-		-- store original scaling rate
-		if not other.ability.cry_scaling_info then
-			other.ability.cry_scaling_info = {
-				[args.scalar_value] = current_scalar,
+			-- store original scaling rate
+			if not other.ability.cry_scaling_info then
+				other.ability.cry_scaling_info = {
+					[context.scalar_value] = context.scalar,
+				}
+			elseif not other.ability.cry_scaling_info[context.scalar_value] then
+				other.ability.cry_scaling_info[context.scalar_value] = context.scalar
+			end
+
+			-- joker scaling stuff
+			local original_scalar = other.ability.cry_scaling_info[context.scalar_value]
+			local new_scale = lenient_bignum(
+				to_big(original_scalar)
+					* (
+						(
+							1
+							+ (
+								(to_big(context.value) / to_big(original_scalar))
+								^ (to_big(1) / to_big(card.ability.extra.scale))
+							)
+						) ^ to_big(card.ability.extra.scale)
+					)
+			)
+			context.scalar_table[context.scalar_value] = new_scale
+
+			return {
+				message = localize("k_upgrade_ex"),
 			}
-		elseif not other.ability.cry_scaling_info[args.scalar_value] then
-			other.ability.cry_scaling_info[args.scalar_value] = current_scalar
 		end
-
-		-- joker scaling stuff
-		local original_scalar = other.ability.cry_scaling_info[args.scalar_value]
-		local new_scale = lenient_bignum(
-			to_big(original_scalar)
-				* (
-					(
-						1
-						+ (
-							(to_big(current_scaling) / to_big(original_scalar))
-							^ (to_big(1) / to_big(card.ability.extra.scale))
-						)
-					) ^ to_big(card.ability.extra.scale)
-				)
-		)
-		args.scalar_table[args.scalar_value] = new_scale
-
-		return {
-			message = localize("k_upgrade_ex"),
-		}
 	end,
 
 	loc_vars = function(self, info_queue, card)


### PR DESCRIPTION
In the new smods version they finally fixed that bug where scaling jokers stayed active after debuff, yay 🫠
Also updated the scaling code to use the new `context.scaling_card` instead of `calc_scaling`