### PR TITLE
Add pinned sticker functionality for booster packs

### DIFF
--- a/lib/modifiers.lua
+++ b/lib/modifiers.lua
@@ -621,6 +621,7 @@ function Card:set_banana(_banana)
 end
 function Card:set_pinned(_pinned)
 	self.ability.pinned = _pinned
+	self.pinned = _pinned
 end
 
 SMODS.Sticker:take_ownership("perishable", {

--- a/lovely/lib_modifiers.toml
+++ b/lovely/lib_modifiers.toml
@@ -18,10 +18,13 @@ if edi.type then
 		card:set_edition({[edi.type] = true})
   	end
 end
-local stickers = {'eternal', 'perishable', 'rental', 'banana'}
+local stickers = {'eternal', 'perishable', 'rental', 'banana', 'pinned'}
 for _, v in ipairs(stickers) do
-	if self.ability[v] then
-		card.ability[v] = self.ability[v]
+	if self.ability[v] or (v == 'pinned' and self.pinned) then
+		card.ability[v] = true
+		if v == 'pinned' then
+			card.pinned = true
+		end
 	end
 end
 '''

--- a/lovely/sticker.toml
+++ b/lovely/sticker.toml
@@ -147,6 +147,7 @@ payload = '''
 local stickers = Cryptid.next_voucher_stickers(true)	-- don't mind the name
 for k, v in pairs(stickers) do
 	card.ability[k] = v
+	if k == 'pinned' and v then card.pinned = true end
 end
 '''
 match_indent = true


### PR DESCRIPTION
Add the *(previously missing)* functionality to booster packs with pinned sticker: all cards in booster pack become pinned (Similar to how other stickers on booster packs work)